### PR TITLE
hide loading screen on map load

### DIFF
--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -3,9 +3,10 @@ interface LoadingScreenProps {
 }
 
 const LoadingScreen: React.FC<LoadingScreenProps> = ({ error }) => {
+  // fixed z-50 to cover entire viewport and stay on top while map loads in the background (map can only load if it's in the DOM)
   if (error) {
     return (
-      <div className="flex items-center justify-center h-screen">
+      <div className="fixed top-0 left-0 right-0 bottom-0 z-50 flex items-center justify-center bg-background">
         <div className="text-red-600 p-4 rounded-md text-center">
           <p>{error}</p>
         </div>
@@ -14,7 +15,7 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({ error }) => {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen bg-background">
+    <div className="fixed top-0 left-0 right-0 bottom-0 z-50 flex flex-col items-center justify-center bg-background">
       <div className="w-64 h-2 bg-gray-200 rounded-full overflow-hidden">
         <div className="loading-bar h-full"></div>
       </div>

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -5,7 +5,11 @@ import maplibregl from "maplibre-gl";
 import { MarkerData, MapProps, FacilityType } from "@/types";
 import { formatTime } from "@/utils/format";
 
-export default function FacilityMap({ facilityData, onMarkerClick }: MapProps) {
+export default function FacilityMap({
+  facilityData,
+  onMarkerClick,
+  onMapLoaded,
+}: MapProps) {
   const handleMarkerClick = useCallback(
     (id: string, type: FacilityType) => {
       onMarkerClick(id, type);
@@ -50,6 +54,9 @@ export default function FacilityMap({ facilityData, onMarkerClick }: MapProps) {
 
     map.current.on("load", () => {
       setIsMapLoaded(true);
+      if (onMapLoaded) {
+        onMapLoaded();
+      }
       handleResize();
       map.current!.setSky({
         "sky-color": "#192c4a",
@@ -76,7 +83,7 @@ export default function FacilityMap({ facilityData, onMarkerClick }: MapProps) {
         map.current = null;
       }
     };
-  }, []);
+  }, [onMapLoaded]);
 
   useEffect(() => {
     if (!map.current || !isMapLoaded || !facilityData) return;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -175,6 +175,7 @@ export interface LibraryCoordinates {
 export interface MapProps {
   facilityData: FacilityStatus | null;
   onMarkerClick: (id: string, facilityType: FacilityType) => void;
+  onMapLoaded?: () => void;
 }
 
 export interface MarkerData {


### PR DESCRIPTION
The map component requires being present in the DOM to initialize properly. Instead of conditional rendering, implemented a parallel loading strategy to allow loading screen to overlay while map hiddenly intializes:

- Render both loading screen and main content simultaneously
- Keep main content hidden with visibility:hidden during initialization
- Use fixed position overlay for loading screen
- Only remove loading screen when both API data and map are ready
- Add onMapLoaded callback to coordinate loading states
- Renamed loading state variables for clarity