### PR TITLE
Add Sentry metrics for scheduled data pipelines

### DIFF
--- a/.github/workflows/course-explorer-weekly.yml
+++ b/.github/workflows/course-explorer-weekly.yml
@@ -44,6 +44,7 @@ jobs:
       SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_ENVIRONMENT: production
+      PYTHONUNBUFFERED: "1"
 
     steps:
       - name: Check out repository
@@ -90,25 +91,59 @@ jobs:
             args+=(--term "$COURSE_TERM")
           fi
 
-          python one_shot_scraper.py "${args[@]}"
+          python sentry_monitor.py run-stage \
+            --monitor-slug course-explorer-weekly \
+            --stage scrape-course-explorer \
+            --label "Scrape Course Explorer" \
+            -- python one_shot_scraper.py "${args[@]}"
 
       - name: Transform subjects into buildings
-        run: python subject_to_buildings.py
+        run: >-
+          python sentry_monitor.py run-stage
+          --monitor-slug course-explorer-weekly
+          --stage transform-subjects
+          --label "Transform subjects into buildings"
+          -- python subject_to_buildings.py
 
       - name: Filter buildings
-        run: python filter_buildings.py
+        run: >-
+          python sentry_monitor.py run-stage
+          --monitor-slug course-explorer-weekly
+          --stage filter-buildings
+          --label "Filter buildings"
+          -- python filter_buildings.py
 
       - name: Add building hours
-        run: python add_building_hours.py
+        run: >-
+          python sentry_monitor.py run-stage
+          --monitor-slug course-explorer-weekly
+          --stage add-building-hours
+          --label "Add building hours"
+          -- python add_building_hours.py
 
       - name: Add building coordinates
-        run: python add_building_coordinates.py
+        run: >-
+          python sentry_monitor.py run-stage
+          --monitor-slug course-explorer-weekly
+          --stage add-building-coordinates
+          --label "Add building coordinates"
+          -- python add_building_coordinates.py
 
       - name: Audit building metadata
-        run: python audit_building_metadata.py
+        run: >-
+          python sentry_monitor.py run-stage
+          --monitor-slug course-explorer-weekly
+          --stage audit-building-metadata
+          --label "Audit building metadata"
+          -- python audit_building_metadata.py
 
       - name: Load course data into Supabase
-        run: python load_to_postgres.py
+        run: >-
+          python sentry_monitor.py run-stage
+          --monitor-slug course-explorer-weekly
+          --stage load-course-data
+          --label "Load course data into Supabase"
+          -- python load_to_postgres.py
 
       - name: Complete Sentry monitor
         if: ${{ always() }}

--- a/.github/workflows/tableau-daily-events.yml
+++ b/.github/workflows/tableau-daily-events.yml
@@ -29,6 +29,7 @@ jobs:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_ENVIRONMENT: production
       PYTHONPATH: .
+      PYTHONUNBUFFERED: "1"
 
     steps:
       - name: Check out repository
@@ -55,7 +56,12 @@ jobs:
           --max-runtime 15
 
       - name: Update Tableau daily events
-        run: python cron/tableau_dailyevents_scraper.py
+        run: >-
+          python sentry_monitor.py run-stage
+          --monitor-slug tableau-daily-events
+          --stage update-daily-events
+          --label "Update Tableau daily events"
+          -- python cron/tableau_dailyevents_scraper.py
 
       - name: Complete Sentry monitor
         if: ${{ always() }}

--- a/data-pipeline/README.MD
+++ b/data-pipeline/README.MD
@@ -91,6 +91,22 @@ Web Data → subjects.json → buildings_derived.json → buildings_filtered.jso
 - Install dependencies: `pip install -r requirements.txt`
 - `.env.local` with `SUPABASE_URL` and `SUPABASE_KEY` (needed for `load_to_postgres.py` and the Tableau cache refresh)
 
+## Scheduled-run observability
+
+Both GitHub Actions pipelines use Sentry Cron Monitors to detect missed, failed,
+and over-time runs. Pipeline stage failures are also reported as Sentry errors
+tagged with the pipeline and exact failing stage. Set the optional `SENTRY_DSN`
+repository secret to enable reporting.
+
+Successful, verified loads emit Sentry Application Metrics for database and
+current-load building, room, class-schedule, and academic-term counts. The
+daily pipeline emits Tableau source rows, valid rows, inserted daily events,
+invalid timestamps, unloadable events, and total skipped events. Weekly metrics
+include academic year and term attributes so they can be filtered in Sentry.
+
+Sentry reporting is best-effort: a Sentry outage does not fail the data
+pipeline, and the original stage command's exit code is always preserved.
+
 ## Quick run
 
 1) Scrape subjects → `subjects.json`  

--- a/data-pipeline/cron/tableau_dailyevents_scraper.py
+++ b/data-pipeline/cron/tableau_dailyevents_scraper.py
@@ -6,6 +6,7 @@ from supabase.client import create_client
 import pandas as pd
 from curl_cffi import requests
 from utils.buildingnames import alias_map
+from sentry_monitor import emit_gauges
 
 
 TABLEAU_CSV_URL = "https://tableau.admin.uillinois.edu/views/DailyEventSummary/DailyEvents.csv"
@@ -112,6 +113,8 @@ def get_events_df():
 
     # Normalize building names using alias map
     df["building_name"] = df["building_name"].map(lambda name: alias_map.get(str(name), str(name)))
+    df.attrs["tableau_rows"] = initial_count
+    df.attrs["invalid_timestamp_events"] = dropped_count
 
     print("Finished processing data")
 
@@ -123,6 +126,10 @@ def load_to_postgres(df):
 
     Args:
         df (DataFrame): Pandas DataFrame containing events data.
+
+    Returns:
+        dict | bool: Inserted and unloadable event counts, or False when no
+            events were inserted.
     """
     supabase = get_supabase_client()
 
@@ -209,7 +216,10 @@ def load_to_postgres(df):
         try:
             supabase.table('daily_events').insert(events_to_insert).execute()
             print(f"Successfully inserted {len(events_to_insert)} events")
-            return True
+            return {
+                "inserted_events": len(events_to_insert),
+                "unloadable_events": len(invalid_events),
+            }
         except Exception as e:
             print(f"Error inserting events: {str(e)}")
             return False
@@ -231,8 +241,8 @@ def main():
     
 
     print("Step 2: Load data to PostgreSQL")
-    success = load_to_postgres(events)
-    if not success:
+    load_counts = load_to_postgres(events)
+    if not load_counts:
         raise RuntimeError("Failed Step 2: No valid events were inserted")
 
     print("Finished Step 2")
@@ -245,6 +255,22 @@ def main():
     except Exception as e:
         print(f"Failed Step 3: Cache refresh error: {e}")
         raise
+
+    invalid_timestamp_events = events.attrs.get("invalid_timestamp_events", 0)
+    unloadable_events = load_counts["unloadable_events"]
+    emit_gauges(
+        {
+            "pipeline.data.tableau_rows": events.attrs.get("tableau_rows", len(events)),
+            "pipeline.data.valid_timestamp_events": len(events),
+            "pipeline.database.daily_events": load_counts["inserted_events"],
+            "pipeline.data.invalid_timestamp_events": invalid_timestamp_events,
+            "pipeline.data.unloadable_events": unloadable_events,
+            "pipeline.data.skipped_events": (
+                invalid_timestamp_events + unloadable_events
+            ),
+        },
+        {"pipeline": "tableau-daily-events"},
+    )
 
     print("Job complete!")
 

--- a/data-pipeline/load_to_postgres.py
+++ b/data-pipeline/load_to_postgres.py
@@ -411,6 +411,7 @@ def main():
                 "pipeline.load.buildings": len(buildings),
                 "pipeline.load.rooms": len(rooms),
                 "pipeline.load.class_schedule_rows": len(schedules),
+                "pipeline.load.academic_terms": len(academic_terms_data),
             },
             get_metric_attributes(data_dir),
         )

--- a/data-pipeline/load_to_postgres.py
+++ b/data-pipeline/load_to_postgres.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Set
 from datetime import datetime
 import os
 from dotenv import load_dotenv, find_dotenv
+from sentry_monitor import emit_gauges
 
 load_dotenv(find_dotenv(".env.local"))
 
@@ -240,7 +241,7 @@ def bulk_insert(table_name: str, records: List[Dict], upsert: bool = False) -> S
 
 def verify_database_contents(
     buildings: List[Dict], rooms: List[Dict], schedules: List[Dict]
-) -> None:
+) -> Dict[str, int]:
     db_buildings_count_response = (
         supabase.table("buildings").select("*", count="exact").execute()
     )
@@ -280,6 +281,11 @@ def verify_database_contents(
     print(f"Verified schedules count: {schedule_count}")
 
     print("All count verifications passed successfully!")
+    return {
+        "buildings": actual_building_count_in_db,
+        "rooms": actual_room_count_in_db,
+        "class_schedule_rows": schedule_count,
+    }
 
 
 def clear_table(table_name: str) -> None:
@@ -306,6 +312,19 @@ def clear_table(table_name: str) -> None:
     except Exception as e:
         print(f"Error clearing table {table_name}: {str(e)}")
         raise
+
+
+def get_metric_attributes(data_dir: Path) -> Dict[str, object]:
+    """Read optional schedule dimensions without making metrics block a load."""
+    attributes: Dict[str, object] = {"pipeline": "course-explorer-weekly"}
+    try:
+        with open(data_dir / "subjects.json", "r") as subject_file:
+            subject_metadata = json.load(subject_file)
+        attributes["academic_year"] = subject_metadata.get("year", "unknown")
+        attributes["term"] = subject_metadata.get("term", "unknown")
+    except (OSError, AttributeError, json.JSONDecodeError) as error:
+        print(f"Unable to read metric dimensions from subjects.json: {error}")
+    return attributes
 
 
 def main():
@@ -357,7 +376,7 @@ def main():
         print(f"Inserted {len(schedule_ids)} schedules")
 
         print("\nPerforming final database verification...")
-        verify_database_contents(buildings, rooms, schedules)
+        database_counts = verify_database_contents(buildings, rooms, schedules)
 
         db_terms_count = (
             supabase.table("academic_terms").select("*", count="exact").execute()
@@ -380,6 +399,21 @@ def main():
         print("\nRefreshing room availability cache...")
         supabase.rpc("refresh_room_availability_cache", {}).execute()
         print("Room availability cache refreshed successfully")
+
+        emit_gauges(
+            {
+                "pipeline.database.buildings": database_counts["buildings"],
+                "pipeline.database.rooms": database_counts["rooms"],
+                "pipeline.database.class_schedule_rows": database_counts[
+                    "class_schedule_rows"
+                ],
+                "pipeline.database.academic_terms": db_terms_count.count,
+                "pipeline.load.buildings": len(buildings),
+                "pipeline.load.rooms": len(rooms),
+                "pipeline.load.class_schedule_rows": len(schedules),
+            },
+            get_metric_attributes(data_dir),
+        )
 
     except DataValidationError as e:
         print(f"\nData Validation Error: {str(e)}")

--- a/data-pipeline/sentry_monitor.py
+++ b/data-pipeline/sentry_monitor.py
@@ -8,25 +8,32 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
+import sys
+import time
 from pathlib import Path
-
-import sentry_sdk
-from sentry_sdk.crons import MonitorStatus, capture_checkin
+from typing import Any, Mapping
 
 
-def initialize_sentry() -> bool:
+def initialize_sentry() -> Any | None:
     dsn = os.getenv("SENTRY_DSN")
     if not dsn:
-        print("SENTRY_DSN is not configured; skipping Sentry monitor check-in")
-        return False
+        print("SENTRY_DSN is not configured; skipping Sentry reporting")
+        return None
 
-    sentry_sdk.init(
-        dsn=dsn,
-        environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
-        release=os.getenv("GITHUB_SHA"),
-        send_default_pii=False,
-    )
-    return True
+    try:
+        import sentry_sdk
+
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
+            release=os.getenv("GITHUB_SHA"),
+            send_default_pii=False,
+        )
+    except Exception as error:
+        print(f"Unable to initialize Sentry; skipping reporting: {error}")
+        return None
+    return sentry_sdk
 
 
 def write_github_output(name: str, value: str) -> None:
@@ -38,8 +45,11 @@ def write_github_output(name: str, value: str) -> None:
 
 def start_monitor(args: argparse.Namespace) -> None:
     check_in_id = ""
-    if initialize_sentry():
+    sentry = initialize_sentry()
+    if sentry:
         try:
+            from sentry_sdk.crons import MonitorStatus, capture_checkin
+
             check_in_id = capture_checkin(
                 monitor_slug=args.monitor_slug,
                 status=MonitorStatus.IN_PROGRESS,
@@ -50,7 +60,7 @@ def start_monitor(args: argparse.Namespace) -> None:
                     "max_runtime": args.max_runtime,
                 },
             )
-            sentry_sdk.flush(timeout=2)
+            sentry.flush(timeout=2)
             print(
                 f"Started Sentry monitor {args.monitor_slug} "
                 f"with check-in {check_in_id}"
@@ -65,20 +75,118 @@ def finish_monitor(args: argparse.Namespace) -> None:
     if not args.check_in_id:
         print("No Sentry check-in ID was created; skipping completion check-in")
         return
-    if not initialize_sentry():
+    sentry = initialize_sentry()
+    if not sentry:
         return
 
     try:
+        from sentry_sdk.crons import MonitorStatus, capture_checkin
+
         status = MonitorStatus.OK if args.status == "ok" else MonitorStatus.ERROR
         capture_checkin(
             monitor_slug=args.monitor_slug,
             check_in_id=args.check_in_id,
             status=status,
         )
-        sentry_sdk.flush(timeout=2)
+        sentry.flush(timeout=2)
         print(f"Completed Sentry monitor {args.monitor_slug} with status {args.status}")
     except Exception as error:
         print(f"Unable to complete Sentry monitor: {error}")
+
+
+def emit_gauges(
+    values: Mapping[str, int | float], attributes: Mapping[str, Any]
+) -> None:
+    """Send pipeline data-volume gauges to Sentry without affecting the load."""
+    sentry = initialize_sentry()
+    if not sentry:
+        return
+
+    try:
+        from sentry_sdk import metrics
+
+        for name, value in values.items():
+            metrics.gauge(name, value, attributes=dict(attributes))
+        sentry.flush(timeout=5)
+        print(f"Sent {len(values)} data-volume metrics to Sentry")
+    except Exception as error:
+        print(f"Unable to send data-volume metrics to Sentry: {error}")
+
+
+def github_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def github_run_url() -> str:
+    repository = os.getenv("GITHUB_REPOSITORY", "")
+    run_id = os.getenv("GITHUB_RUN_ID", "")
+    if not repository or not run_id:
+        return ""
+    server_url = os.getenv("GITHUB_SERVER_URL", "https://github.com")
+    return f"{server_url}/{repository}/actions/runs/{run_id}"
+
+
+def report_stage_failure(
+    args: argparse.Namespace, exit_code: int, duration_seconds: float
+) -> None:
+    """Send the exact failed stage to Sentry without masking the pipeline error."""
+    sentry = initialize_sentry()
+    if not sentry:
+        return
+
+    try:
+        with sentry.new_scope() as scope:
+            scope.set_tag("pipeline", args.monitor_slug)
+            scope.set_tag("pipeline.stage", args.stage)
+            scope.set_tag("github.run_id", os.getenv("GITHUB_RUN_ID", ""))
+            scope.set_tag("github.run_attempt", os.getenv("GITHUB_RUN_ATTEMPT", ""))
+            scope.set_context(
+                "pipeline_stage",
+                {
+                    "label": args.label,
+                    "exit_code": exit_code,
+                    "duration_seconds": duration_seconds,
+                    "workflow": os.getenv("GITHUB_WORKFLOW", ""),
+                    "ref": os.getenv("GITHUB_REF_NAME", ""),
+                    "run_url": github_run_url(),
+                },
+            )
+            sentry.capture_message(
+                f"Pipeline stage failed: {args.label}", level="error"
+            )
+        sentry.flush(timeout=2)
+    except Exception as error:
+        print(f"Unable to report stage failure to Sentry: {error}")
+
+
+def run_stage(args: argparse.Namespace) -> int:
+    stage_command = list(args.stage_command)
+    if stage_command and stage_command[0] == "--":
+        stage_command.pop(0)
+    if not stage_command:
+        raise ValueError("A command is required after --")
+
+    print(f"Starting pipeline stage: {args.label}", flush=True)
+    started_at = time.monotonic()
+    try:
+        result = subprocess.run(stage_command, check=False)
+        exit_code = result.returncode
+    except OSError as error:
+        print(f"Unable to start stage command: {error}", file=sys.stderr, flush=True)
+        exit_code = 127 if isinstance(error, FileNotFoundError) else 126
+
+    duration_seconds = round(time.monotonic() - started_at, 3)
+    if exit_code == 0:
+        print(
+            f"Completed pipeline stage: {args.label} ({duration_seconds:.1f}s)",
+            flush=True,
+        )
+        return 0
+
+    message = f"{args.label} exited with code {exit_code} after {duration_seconds:.1f}s"
+    print(f"::error title=Pipeline stage failed::{github_escape(message)}", flush=True)
+    report_stage_failure(args, exit_code, duration_seconds)
+    return exit_code
 
 
 def parse_args() -> argparse.Namespace:
@@ -98,13 +206,22 @@ def parse_args() -> argparse.Namespace:
     finish_parser.add_argument("--status", choices=("ok", "error"), required=True)
     finish_parser.set_defaults(handler=finish_monitor)
 
+    stage_parser = subparsers.add_parser(
+        "run-stage", help="Run a pipeline stage and report failures to Sentry"
+    )
+    stage_parser.add_argument("--monitor-slug", required=True)
+    stage_parser.add_argument("--stage", required=True)
+    stage_parser.add_argument("--label", required=True)
+    stage_parser.add_argument("stage_command", nargs=argparse.REMAINDER)
+    stage_parser.set_defaults(handler=run_stage)
+
     return parser.parse_args()
 
 
-def main() -> None:
+def main() -> int:
     args = parse_args()
-    args.handler(args)
+    return args.handler(args) or 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- emit Sentry Application Metrics after successful, verified weekly and daily loads
- report exact pipeline-stage failures to Sentry with GitHub run context
- keep all Sentry reporting best-effort so observability cannot fail a pipeline

## Metrics

Weekly runs emit database and current-load gauges for buildings, rooms, class schedule rows, and academic terms, attributed by academic year and term.

Daily runs emit Tableau rows, valid timestamp rows, inserted daily events, invalid timestamp events, unloadable events, and total skipped events.

## Validation

- Python compilation for all changed pipeline modules
- YAML parsing for both GitHub Actions workflows
- `git diff --check`
- verified `metrics.gauge` and attribute support against pinned `sentry-sdk==2.66.0`

## Follow-up

After the first successful runs populate these series, configure threshold or anomaly monitors in Sentry for the metrics that should alert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring for scheduled data-pipeline runs, including stage-level status and failure reporting.
  - Added metrics for fetched, validated, skipped, inserted, and verified records.
  - Added database record-count metrics with optional academic-term context.
  - Added links to related workflow runs in monitoring events.

- **Bug Fixes**
  - Monitoring failures no longer interrupt data processing or alter pipeline exit statuses.

- **Documentation**
  - Documented scheduled-run monitoring, configuration, metrics, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds best-effort Sentry metrics and stage-level failure reporting to the scheduled weekly and daily data pipelines.
- Wraps workflow stages while preserving their process exit status.
- Emits data-volume gauges after successful pipeline verification.
- Adds GitHub run metadata to captured stage failures.
- Documents the scheduled-run observability behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| data-pipeline/sentry_monitor.py | Adds best-effort Sentry initialization, metric emission, stage execution, and contextual failure reporting without an accepted blocking issue. |
| data-pipeline/cron/tableau_dailyevents_scraper.py | Tracks source, validation, insertion, and skipped-event counts and emits them after a successful load and cache refresh. |
| data-pipeline/load_to_postgres.py | Returns verified database counts and emits weekly load and database gauges with optional academic dimensions. |
| .github/workflows/course-explorer-weekly.yml | Routes weekly pipeline stages through the monitoring wrapper and enables unbuffered process output. |
| .github/workflows/tableau-daily-events.yml | Routes the daily update through the monitoring wrapper and enables unbuffered process output. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Wrapper as sentry_monitor.py
    participant Stage as Pipeline stage
    participant DB as Supabase
    participant Sentry
    GHA->>Wrapper: run-stage -- stage command
    Wrapper->>Stage: subprocess.run(argv)
    Stage->>DB: Load and verify data
    alt Stage succeeds
        Stage->>Sentry: Emit verified volume gauges
        Stage-->>Wrapper: Exit 0
    else Stage fails
        Stage-->>Wrapper: Nonzero exit
        Wrapper->>Sentry: Capture stage failure and run context
    end
    Wrapper-->>GHA: Preserve stage result
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Emit current-load academic term metric"](https://github.com/plon/illinispots/commit/a689b48a39806425bf8c74be641dc5300d1ca1f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54199499)</sub>

<!-- /greptile_comment -->