### PR TITLE
Optimize cached spots lookup and track fallbacks

### DIFF
--- a/database/functions/get_cached_spots.sql
+++ b/database/functions/get_cached_spots.sql
@@ -9,11 +9,12 @@ DECLARE
     check_timestamp TIMESTAMP;
     min_interval INTERVAL;
 BEGIN
-    SET LOCAL statement_timeout = '6s';
-
     -- If cache doesn't exist for this date, fall back to real-time calculation
     IF NOT EXISTS (SELECT 1 FROM room_availability_cache WHERE check_date = check_date_param LIMIT 1) THEN
-        result := get_spots(check_time_param, check_date_param, min_minutes_param);
+        result := COALESCE(
+            get_spots(check_time_param, check_date_param, min_minutes_param),
+            '{}'::jsonb
+        );
         RETURN result || jsonb_build_object(
             '_cache', jsonb_build_object(
                 'hit', false,
@@ -75,7 +76,8 @@ BEGIN
                 WITH ORDINALITY as activity(item, ordinality)
         ) matches
         WHERE c.check_date = check_date_param
-          AND bi.open_time IS NOT NULL -- Only consider open buildings
+          AND bi.open_time IS NOT NULL
+          AND bi.close_time IS NOT NULL -- Only consider buildings with valid hours
     ),
     calculated_availability AS MATERIALIZED (
         SELECT

--- a/src/app/api/facilities/route.ts
+++ b/src/app/api/facilities/route.ts
@@ -832,12 +832,52 @@ async function fetchAcademicBuildingData(
         name: "Supabase RPC get_cached_spots",
         op: "db.rpc",
       },
-      () =>
-        supabase.rpc("get_cached_spots", {
+      async (span) => {
+        const response = await supabase.rpc("get_cached_spots", {
           check_time_param: targetMoment.format("HH:mm:ss"),
           check_date_param: targetMoment.format("YYYY-MM-DD"),
           min_minutes_param: 30,
-        }),
+        });
+
+        const cacheMetadata = (
+          response.data as {
+            _cache?: {
+              hit?: boolean;
+              source?: string;
+              reason?: string;
+            };
+          } | null
+        )?._cache;
+        const cacheResult = response.error
+          ? "error"
+          : cacheMetadata?.hit === true
+            ? "hit"
+            : cacheMetadata?.hit === false
+              ? "fallback"
+              : "unknown";
+
+        span.setAttributes({
+          "cache.result": cacheResult,
+          "cache.hit": cacheMetadata?.hit,
+          "cache.source": cacheMetadata?.source,
+          "cache.fallback_reason": cacheMetadata?.reason,
+          "availability.check_date": targetMoment.format("YYYY-MM-DD"),
+        });
+
+        if (cacheResult === "fallback") {
+          span.addEvent("cache.fallback", {
+            "fallback.operation": "get_spots",
+            "fallback.reason": cacheMetadata?.reason ?? "unknown",
+            "availability.check_date": targetMoment.format("YYYY-MM-DD"),
+          });
+        }
+
+        Sentry.metrics.count("academic_availability.cache_lookup", 1, {
+          attributes: { result: cacheResult },
+        });
+
+        return response;
+      },
     );
 
     if (error) {

--- a/src/app/api/facilities/route.ts
+++ b/src/app/api/facilities/route.ts
@@ -856,25 +856,29 @@ async function fetchAcademicBuildingData(
               ? "fallback"
               : "unknown";
 
-        span.setAttributes({
-          "cache.result": cacheResult,
-          "cache.hit": cacheMetadata?.hit,
-          "cache.source": cacheMetadata?.source,
-          "cache.fallback_reason": cacheMetadata?.reason,
-          "availability.check_date": targetMoment.format("YYYY-MM-DD"),
-        });
-
-        if (cacheResult === "fallback") {
-          span.addEvent("cache.fallback", {
-            "fallback.operation": "get_spots",
-            "fallback.reason": cacheMetadata?.reason ?? "unknown",
+        try {
+          span.setAttributes({
+            "cache.result": cacheResult,
+            "cache.hit": cacheMetadata?.hit,
+            "cache.source": cacheMetadata?.source,
+            "cache.fallback_reason": cacheMetadata?.reason,
             "availability.check_date": targetMoment.format("YYYY-MM-DD"),
           });
-        }
 
-        Sentry.metrics.count("academic_availability.cache_lookup", 1, {
-          attributes: { result: cacheResult },
-        });
+          if (cacheResult === "fallback") {
+            span.addEvent("cache.fallback", {
+              "fallback.operation": "get_spots",
+              "fallback.reason": cacheMetadata?.reason ?? "unknown",
+              "availability.check_date": targetMoment.format("YYYY-MM-DD"),
+            });
+          }
+
+          Sentry.metrics.count("academic_availability.cache_lookup", 1, {
+            attributes: { result: cacheResult },
+          });
+        } catch (telemetryError) {
+          console.warn("Cache telemetry failed:", telemetryError);
+        }
 
         return response;
       },

--- a/supabase/migrations/20260818000000_optimize_get_cached_spots.sql
+++ b/supabase/migrations/20260818000000_optimize_get_cached_spots.sql
@@ -1,4 +1,9 @@
-CREATE OR REPLACE FUNCTION get_cached_spots(
+-- Avoid repeatedly expanding and sorting every room's cached JSON schedule.
+-- The schedule is already stored in start-time order by
+-- refresh_room_availability_cache, so one pass can locate both the current and
+-- next activity. Materialized CTEs prevent PostgreSQL from inlining those
+-- lookups once for every output field that consumes them.
+CREATE OR REPLACE FUNCTION public.get_cached_spots(
     check_time_param TIME,
     check_date_param DATE,
     min_minutes_param INTEGER DEFAULT 30
@@ -26,11 +31,10 @@ BEGIN
     min_interval := (min_minutes_param || ' minutes')::interval;
 
     WITH building_info AS MATERIALIZED (
-        SELECT 
+        SELECT
             b.name,
             b.latitude,
             b.longitude,
-            -- Determine open/close for this specific day
             CASE EXTRACT(DOW FROM check_date_param)
                 WHEN 1 THEN b.monday_open WHEN 2 THEN b.tuesday_open WHEN 3 THEN b.wednesday_open
                 WHEN 4 THEN b.thursday_open WHEN 5 THEN b.friday_open WHEN 6 THEN b.saturday_open
@@ -43,23 +47,15 @@ BEGIN
             END as close_time
         FROM buildings b
     ),
-    -- Materialize the expensive JSON extraction. Without this barrier,
-    -- PostgreSQL can inline the CTE and evaluate each correlated JSON scan
-    -- again for currentClass, nextClass, and the availability metrics.
     room_state AS MATERIALIZED (
         SELECT
             c.building_name,
             c.room_number,
             bi.open_time,
             bi.close_time,
-            -- Is the room currently occupied?
             (c.busy_times @> check_timestamp) as is_occupied,
-
-            -- schedule_data is written in start-time order. Expand it once
-            -- and use the first matching array positions for both lookups.
             c.schedule_data -> ((matches.current_ordinal - 1)::integer) as current_class_json,
             c.schedule_data -> ((matches.next_ordinal - 1)::integer) as next_class_json
-
         FROM room_availability_cache c
         JOIN building_info bi ON c.building_name = bi.name
         CROSS JOIN LATERAL (
@@ -75,17 +71,14 @@ BEGIN
                 WITH ORDINALITY as activity(item, ordinality)
         ) matches
         WHERE c.check_date = check_date_param
-          AND bi.open_time IS NOT NULL -- Only consider open buildings
+          AND bi.open_time IS NOT NULL
     ),
     calculated_availability AS MATERIALIZED (
         SELECT
             rs.*,
-            -- Extract timestamps from JSON for easier math
             (rs.current_class_json->>'end')::time as current_end_time,
             (rs.next_class_json->>'start')::time as next_start_time,
-            
-            -- Calculate Available Until
-            CASE 
+            CASE
                 WHEN NOT rs.is_occupied THEN
                     COALESCE((rs.next_class_json->>'start')::time, rs.close_time)
                 ELSE NULL
@@ -95,33 +88,22 @@ BEGIN
     final_metrics AS MATERIALIZED (
         SELECT
             ca.*,
-            CASE 
-                WHEN is_occupied THEN 'occupied' 
-                ELSE 'available' 
+            CASE
+                WHEN is_occupied THEN 'occupied'
+                ELSE 'available'
             END as status_text,
-            
-            -- passingPeriod logic: Available, but for less than min interval
             (NOT is_occupied AND (available_until_time - check_time_param) < min_interval) as is_passing_period,
-            
-            -- availableFor logic
-            CASE 
-                WHEN NOT is_occupied THEN 
+            CASE
+                WHEN NOT is_occupied THEN
                     EXTRACT(EPOCH FROM (available_until_time - check_time_param))/60
-                ELSE 
-                    -- If occupied, complex logic for "when next available". 
-                    -- Simplified: Available at end of current class.
-                    -- Does NOT do recursive gap check (too complex for simple cache read)
-                    NULL
+                ELSE NULL
             END as available_for_minutes,
-            
-            -- availableAt logic
             CASE
                 WHEN is_occupied THEN current_end_time
                 ELSE NULL
             END as available_at_time
         FROM calculated_availability ca
     ),
-    -- Aggregation per building
     building_agg AS (
         SELECT
             bi.name,

--- a/supabase/migrations/20260818000000_optimize_get_cached_spots.sql
+++ b/supabase/migrations/20260818000000_optimize_get_cached_spots.sql
@@ -14,11 +14,12 @@ DECLARE
     check_timestamp TIMESTAMP;
     min_interval INTERVAL;
 BEGIN
-    SET LOCAL statement_timeout = '6s';
-
     -- If cache doesn't exist for this date, fall back to real-time calculation
     IF NOT EXISTS (SELECT 1 FROM room_availability_cache WHERE check_date = check_date_param LIMIT 1) THEN
-        result := get_spots(check_time_param, check_date_param, min_minutes_param);
+        result := COALESCE(
+            get_spots(check_time_param, check_date_param, min_minutes_param),
+            '{}'::jsonb
+        );
         RETURN result || jsonb_build_object(
             '_cache', jsonb_build_object(
                 'hit', false,
@@ -72,6 +73,7 @@ BEGIN
         ) matches
         WHERE c.check_date = check_date_param
           AND bi.open_time IS NOT NULL
+          AND bi.close_time IS NOT NULL
     ),
     calculated_availability AS MATERIALIZED (
         SELECT
@@ -148,3 +150,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql
 SET search_path = pg_catalog, public;
+
+-- PostgREST serves this RPC with the anon role. A role-level timeout is active
+-- when the RPC statement starts; changing statement_timeout inside the function
+-- would not affect the already-running outer statement.
+ALTER ROLE anon SET statement_timeout = '6s';
+NOTIFY pgrst, 'reload config';


### PR DESCRIPTION
## Summary
- expand each cached room schedule once and remove the redundant per-room sort
- materialize availability stages to prevent PostgreSQL from repeating JSON extraction
- annotate cached responses with internal hit/fallback metadata
- add Sentry span attributes, fallback events, and a cache lookup counter

## Observability
The `Supabase RPC get_cached_spots` span now records `cache.result`, `cache.hit`, `cache.source`, `cache.fallback_reason`, and `availability.check_date`. The `academic_availability.cache_lookup` metric can be grouped by `result` to measure fallback rate.

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`

Database timing should be compared after applying the migration; no production performance improvement is claimed before deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimized room availability retrieval for faster results.
  * Availability responses now include cache status information when relevant.
  * Requests automatically fall back to live availability when cached data is unavailable.
  * Results continue to include current and upcoming room activity details.

* **Bug Fixes**
  * Improved reliability when requesting availability for dates without cached data.
  * Added safeguards to prevent lengthy availability requests from affecting responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR optimizes cached room-schedule processing and adds cache-hit and fallback observability.
- Expands each cached schedule once and materializes availability calculation stages.
- Adds internal cache metadata to cached and fallback responses.
- Records cache outcomes through Sentry span attributes, events, and metrics.
- Moves the cached-spots timeout to an anon-role setting in the deployment migration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| database/functions/get_cached_spots.sql | Optimizes cached schedule extraction through one lateral expansion and materialized calculation stages, then annotates the JSON response with cache metadata. |
| src/app/api/facilities/route.ts | Reads internal cache metadata from the RPC response and records cache outcomes without allowing telemetry failures to interrupt the response. |
| supabase/migrations/20260818000000_optimize_get_cached_spots.sql | Deploys the optimized RPC implementation, cache metadata, and anon-role statement timeout. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Facilities API request] --> B[get_cached_spots RPC]
    B --> C{Cache exists for date?}
    C -->|No| D[get_spots live fallback]
    D --> E[Attach fallback metadata]
    C -->|Yes| F[Expand cached schedules]
    F --> G[Calculate room availability]
    G --> H[Attach cache-hit metadata]
    E --> I[Record Sentry attributes and metric]
    H --> I
    I --> J[Build facilities response]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Address cached spots review feedback"](https://github.com/plon/illinispots/commit/b0dd1e92d2c8e0ac28441c621effb0d49386f4d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54524215)</sub>

<!-- /greptile_comment -->