### PR TITLE
Add unified building and room search

### DIFF
--- a/src/components/BuildingSearchResultCard.tsx
+++ b/src/components/BuildingSearchResultCard.tsx
@@ -12,20 +12,14 @@ import {
   ChevronUp,
   Clock,
   DoorOpen,
-  MapPin,
-  ExternalLink,
 } from "lucide-react";
 
 interface BuildingSearchResultCardProps {
   buildingResult: SearchResultBuilding;
-  onBuildingClick?: (facilityId: string, type: "library" | "academic") => void;
-  onOpenInAccordion?: (facilityId: string, type: "library" | "academic") => void;
 }
 
 export const BuildingSearchResultCard: React.FC<BuildingSearchResultCardProps> = ({
   buildingResult,
-  onBuildingClick,
-  onOpenInAccordion,
 }) => {
   const [isRoomsOpen, setIsRoomsOpen] = useState(false);
   const {
@@ -39,16 +33,6 @@ export const BuildingSearchResultCard: React.FC<BuildingSearchResultCardProps> =
 
   const isLibrary = facilityType === FacilityType.LIBRARY;
   const isOpen = facility.isOpen;
-
-  const handleLocateClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onBuildingClick?.(facility.id, isLibrary ? "library" : "academic");
-  };
-
-  const handleOpenAccordion = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onOpenInAccordion?.(facility.id, isLibrary ? "library" : "academic");
-  };
 
   // Prepare rooms for preview (matching rooms or all rooms in facility)
   const previewRooms = React.useMemo(() => {
@@ -153,58 +137,28 @@ export const BuildingSearchResultCard: React.FC<BuildingSearchResultCardProps> =
       </div>
 
       {/* Actions Row */}
-      <div className="flex items-center justify-between gap-2 pt-1">
-        <div className="flex items-center gap-2">
-          {/* Toggle Rooms Button */}
-          {previewRooms.length > 0 && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setIsRoomsOpen(!isRoomsOpen)}
-              className="h-8 text-xs font-medium gap-1.5 hover:bg-secondary"
-              aria-expanded={isRoomsOpen}
-            >
-              <DoorOpen className="w-3.5 h-3.5" />
-              {isRoomsOpen
-                ? "Hide Rooms"
-                : `View Rooms (${previewRooms.length})`}
-              {isRoomsOpen ? (
-                <ChevronUp className="w-3.5 h-3.5 ml-0.5" />
-              ) : (
-                <ChevronDown className="w-3.5 h-3.5 ml-0.5" />
-              )}
-            </Button>
-          )}
-
-          {/* Open in Accordion View Button */}
-          {onOpenInAccordion && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={handleOpenAccordion}
-              className="h-8 text-xs text-muted-foreground hover:text-foreground gap-1"
-              title="Open building in accordion view"
-            >
-              <ExternalLink className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">Open in list</span>
-            </Button>
-          )}
-        </div>
-
-        {/* Locate on Map Button */}
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={handleLocateClick}
-          className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground gap-1"
-          title="Locate building on map"
-        >
-          <MapPin className="w-3.5 h-3.5 text-primary" />
-          <span className="hidden sm:inline">Locate</span>
-        </Button>
+      <div className="flex items-center gap-2 pt-1">
+        {/* Toggle Rooms Button */}
+        {previewRooms.length > 0 && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setIsRoomsOpen(!isRoomsOpen)}
+            className="h-8 text-xs font-medium gap-1.5 hover:bg-secondary"
+            aria-expanded={isRoomsOpen}
+          >
+            <DoorOpen className="w-3.5 h-3.5" />
+            {isRoomsOpen
+              ? "Hide Rooms"
+              : `View Rooms (${previewRooms.length})`}
+            {isRoomsOpen ? (
+              <ChevronUp className="w-3.5 h-3.5 ml-0.5" />
+            ) : (
+              <ChevronDown className="w-3.5 h-3.5 ml-0.5" />
+            )}
+          </Button>
+        )}
       </div>
 
       {/* Collapsible Rooms List */}
@@ -218,7 +172,6 @@ export const BuildingSearchResultCard: React.FC<BuildingSearchResultCardProps> =
               <RoomSearchResultCard
                 key={`${roomResult.facilityId}-${roomResult.roomNumber}`}
                 roomResult={roomResult}
-                onBuildingClick={onBuildingClick}
               />
             ))}
           </div>

--- a/src/components/BuildingSearchResultCard.tsx
+++ b/src/components/BuildingSearchResultCard.tsx
@@ -1,0 +1,229 @@
+import React, { useState } from "react";
+import { SearchResultBuilding } from "@/utils/searchUtils";
+import { FacilityType, RoomStatus } from "@/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { formatTime } from "@/utils/format";
+import { getLibraryHoursMessage } from "@/utils/libraryHours";
+import { RoomSearchResultCard } from "@/components/RoomSearchResultCard";
+import {
+  Building2,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  DoorOpen,
+  MapPin,
+  ExternalLink,
+} from "lucide-react";
+
+interface BuildingSearchResultCardProps {
+  buildingResult: SearchResultBuilding;
+  onBuildingClick?: (facilityId: string, type: "library" | "academic") => void;
+  onOpenInAccordion?: (facilityId: string, type: "library" | "academic") => void;
+}
+
+export const BuildingSearchResultCard: React.FC<BuildingSearchResultCardProps> = ({
+  buildingResult,
+  onBuildingClick,
+  onOpenInAccordion,
+}) => {
+  const [isRoomsOpen, setIsRoomsOpen] = useState(false);
+  const {
+    facility,
+    facilityName,
+    facilityType,
+    availableRoomsCount,
+    totalRoomsCount,
+    matchingRooms,
+  } = buildingResult;
+
+  const isLibrary = facilityType === FacilityType.LIBRARY;
+  const isOpen = facility.isOpen;
+
+  const handleLocateClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onBuildingClick?.(facility.id, isLibrary ? "library" : "academic");
+  };
+
+  const handleOpenAccordion = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onOpenInAccordion?.(facility.id, isLibrary ? "library" : "academic");
+  };
+
+  // Prepare rooms for preview (matching rooms or all rooms in facility)
+  const previewRooms = React.useMemo(() => {
+    if (matchingRooms.length > 0) {
+      return matchingRooms;
+    }
+    // Fallback: all rooms in this facility formatted as SearchResultRoom
+    return Object.entries(facility.rooms)
+      .map(([roomNumber, room]) => ({
+        type: "room" as const,
+        roomNumber,
+        facilityId: facility.id,
+        facilityName: facility.name,
+        facilityType: facility.type,
+        room,
+        facility,
+        score: 0.5,
+      }))
+      .sort((a, b) => {
+        const isAvailA =
+          a.room.status === RoomStatus.AVAILABLE ||
+          a.room.status === RoomStatus.PASSING_PERIOD;
+        const isAvailB =
+          b.room.status === RoomStatus.AVAILABLE ||
+          b.room.status === RoomStatus.PASSING_PERIOD;
+        if (isAvailA !== isAvailB) return isAvailA ? -1 : 1;
+        return a.roomNumber.localeCompare(b.roomNumber, undefined, {
+          numeric: true,
+          sensitivity: "base",
+        });
+      });
+  }, [matchingRooms, facility]);
+
+  return (
+    <div className="rounded-lg border border-border/80 bg-card p-3.5 shadow-xs hover:border-primary/40 transition-all duration-150 space-y-2.5">
+      {/* Header: Name, Type, and Badge */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <Building2 className="w-4 h-4 text-primary shrink-0" />
+            <h3 className="font-semibold text-base text-foreground tracking-tight truncate">
+              {facilityName}
+            </h3>
+          </div>
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            <Badge
+              variant="secondary"
+              className="text-[10px] uppercase font-semibold tracking-wider h-4 px-1.5 bg-muted text-muted-foreground"
+            >
+              {isLibrary ? "Library" : "Academic"}
+            </Badge>
+            {facility.address && (
+              <span className="text-[11px] text-muted-foreground truncate max-w-[220px]">
+                {facility.address}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Status Badge */}
+        <div className="shrink-0">
+          {!isOpen ? (
+            <Badge
+              variant="outline"
+              className="bg-gray-50 text-gray-700 border-gray-300 text-xs"
+            >
+              CLOSED
+            </Badge>
+          ) : (
+            <Badge
+              variant="outline"
+              className={`text-xs ${
+                availableRoomsCount > 0
+                  ? "bg-green-50 text-green-700 border-green-300"
+                  : "bg-red-50 text-red-700 border-red-300"
+              }`}
+            >
+              {availableRoomsCount}/{totalRoomsCount} Available
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Operating Hours Info */}
+      <div className="text-xs text-muted-foreground flex items-center gap-1.5 bg-muted/20 rounded-md px-2.5 py-1.5 border border-border/30">
+        <Clock className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />
+        {isLibrary ? (
+          <span>{getLibraryHoursMessage(facility.name)}</span>
+        ) : isOpen ? (
+          <span>
+            Open today
+            {facility.hours?.open && facility.hours?.close && (
+              <> ({formatTime(facility.hours.open)} - {formatTime(facility.hours.close)})</>
+            )}
+          </span>
+        ) : (
+          <span>
+            Closed
+            {facility.hours?.open ? ` • Opens at ${formatTime(facility.hours.open)}` : " • Not open today"}
+          </span>
+        )}
+      </div>
+
+      {/* Actions Row */}
+      <div className="flex items-center justify-between gap-2 pt-1">
+        <div className="flex items-center gap-2">
+          {/* Toggle Rooms Button */}
+          {previewRooms.length > 0 && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setIsRoomsOpen(!isRoomsOpen)}
+              className="h-8 text-xs font-medium gap-1.5 hover:bg-secondary"
+              aria-expanded={isRoomsOpen}
+            >
+              <DoorOpen className="w-3.5 h-3.5" />
+              {isRoomsOpen
+                ? "Hide Rooms"
+                : `View Rooms (${previewRooms.length})`}
+              {isRoomsOpen ? (
+                <ChevronUp className="w-3.5 h-3.5 ml-0.5" />
+              ) : (
+                <ChevronDown className="w-3.5 h-3.5 ml-0.5" />
+              )}
+            </Button>
+          )}
+
+          {/* Open in Accordion View Button */}
+          {onOpenInAccordion && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleOpenAccordion}
+              className="h-8 text-xs text-muted-foreground hover:text-foreground gap-1"
+              title="Open building in accordion view"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+              <span className="hidden sm:inline">Open in list</span>
+            </Button>
+          )}
+        </div>
+
+        {/* Locate on Map Button */}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleLocateClick}
+          className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground gap-1"
+          title="Locate building on map"
+        >
+          <MapPin className="w-3.5 h-3.5 text-primary" />
+          <span className="hidden sm:inline">Locate</span>
+        </Button>
+      </div>
+
+      {/* Collapsible Rooms List */}
+      {isRoomsOpen && (
+        <div className="pt-2 border-t border-border/60 mt-2 space-y-2">
+          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider pl-1">
+            Rooms in {facility.name} ({previewRooms.length})
+          </p>
+          <div className="space-y-2 max-h-[360px] overflow-y-auto pr-1">
+            {previewRooms.map((roomResult) => (
+              <RoomSearchResultCard
+                key={`${roomResult.facilityId}-${roomResult.roomNumber}`}
+                roomResult={roomResult}
+                onBuildingClick={onBuildingClick}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/FacilityAccordion.tsx
+++ b/src/components/FacilityAccordion.tsx
@@ -32,7 +32,7 @@ interface FacilityAccordionProps {
   filterCriteria?: FilterCriteria;
 }
 
-const getRoomAvailabilityMessage = (room: LibraryRoom): React.ReactNode => {
+export const getRoomAvailabilityMessage = (room: LibraryRoom): React.ReactNode => {
   if (room.status === RoomStatus.UNAVAILABLE) {
     return <span className="text-xs text-muted-foreground">Unavailable</span>;
   } else if (room.status === RoomStatus.AVAILABLE) {

--- a/src/components/FacilityRoomDetails.tsx
+++ b/src/components/FacilityRoomDetails.tsx
@@ -79,7 +79,7 @@ const TimeBlock = ({ slot }: TimeBlockProps) => {
   );
 };
 
-const RoomSchedule = ({ slots }: RoomScheduleProps) => {
+export const RoomSchedule = ({ slots }: RoomScheduleProps) => {
   const slotDurations = useMemo(() => {
     if (slots.length === 0) return { common: 0, all: [] };
 

--- a/src/components/RoomFilter.tsx
+++ b/src/components/RoomFilter.tsx
@@ -12,7 +12,7 @@ import {
     DrawerTrigger,
 } from "@/components/ui/drawer";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import { ListFilter, Hourglass, Clock, Building2, DoorOpen, Search } from "lucide-react";
+import { ListFilter, Hourglass, Clock } from "lucide-react";
 
 const PRESET_DURATIONS = [30, 60, 120, 240] as const;
 const MIN_CUSTOM_DURATION = 1;
@@ -27,8 +27,6 @@ interface RoomFilterPopoverProps {
     hasActiveFilters: boolean;
     onClearAll: () => void;
     matchingRoomsCount: number;
-    searchMode: "facilities" | "rooms";
-    setSearchMode: (mode: "facilities" | "rooms") => void;
 }
 
 const RoomFilterPopover: React.FC<RoomFilterPopoverProps> = ({
@@ -41,8 +39,6 @@ const RoomFilterPopover: React.FC<RoomFilterPopoverProps> = ({
     hasActiveFilters,
     onClearAll,
     matchingRoomsCount,
-    searchMode,
-    setSearchMode,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
     const isDesktop = useMediaQuery("(min-width: 768px)");
@@ -138,38 +134,7 @@ const RoomFilterPopover: React.FC<RoomFilterPopoverProps> = ({
                     )}
                 </div>
 
-                <div className="space-y-3">
-                    <div className="flex items-center gap-2 text-sm font-medium text-foreground/80">
-                        <Search size={14} className="text-muted-foreground" />
-                        Search By
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                        <Button
-                            variant={searchMode === "facilities" ? "default" : "outline"}
-                            size="sm"
-                            onClick={() => setSearchMode("facilities")}
-                            className={`h-9 text-xs font-medium transition-all flex items-center gap-1.5 ${searchMode === "facilities"
-                                ? "shadow-sm"
-                                : "hover:border-primary/50 hover:bg-primary/5"
-                                }`}
-                        >
-                            <Building2 size={14} />
-                            Building
-                        </Button>
-                        <Button
-                            variant={searchMode === "rooms" ? "default" : "outline"}
-                            size="sm"
-                            onClick={() => setSearchMode("rooms")}
-                            className={`h-9 text-xs font-medium transition-all flex items-center gap-1.5 ${searchMode === "rooms"
-                                ? "shadow-sm"
-                                : "hover:border-primary/50 hover:bg-primary/5"
-                                }`}
-                        >
-                            <DoorOpen size={14} />
-                            Room
-                        </Button>
-                    </div>
-                </div>
+
 
                 <div className="space-y-3">
                     <div className="flex items-center justify-between">

--- a/src/components/RoomSearchResultCard.tsx
+++ b/src/components/RoomSearchResultCard.tsx
@@ -1,0 +1,252 @@
+import React, { useState } from "react";
+import { SearchResultRoom } from "@/utils/searchUtils";
+import { AcademicRoom, FacilityType, LibraryRoom, RoomStatus } from "@/types";
+import { RoomBadge } from "@/components/RoomBadge";
+import { formatDuration, formatTime } from "@/utils/format";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import AcademicRoomDetailLoader from "@/components/AcademicRoomDetailLoader";
+import { RoomSchedule } from "@/components/FacilityRoomDetails";
+import { getRoomAvailabilityMessage } from "@/components/FacilityAccordion";
+import {
+  Building2,
+  Calendar,
+  ChevronDown,
+  ChevronUp,
+  BookOpen,
+  Image as ImageIcon,
+  Clock,
+  MapPin,
+} from "lucide-react";
+import Image from "next/image";
+
+interface RoomSearchResultCardProps {
+  roomResult: SearchResultRoom;
+  onBuildingClick?: (facilityId: string, type: "library" | "academic") => void;
+}
+
+export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
+  roomResult,
+  onBuildingClick,
+}) => {
+  const [isScheduleOpen, setIsScheduleOpen] = useState(false);
+  const [isImageLoading, setIsImageLoading] = useState(true);
+
+  const { room, facility, roomNumber, facilityType } = roomResult;
+  const isAcademic = facilityType === FacilityType.ACADEMIC;
+  const academicRoom = isAcademic ? (room as AcademicRoom) : null;
+  const libraryRoom = !isAcademic ? (room as LibraryRoom) : null;
+
+  const handleFacilityClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onBuildingClick?.(
+      facility.id,
+      facilityType === FacilityType.LIBRARY ? "library" : "academic",
+    );
+  };
+
+  return (
+    <div className="rounded-lg border border-border/80 bg-card p-3.5 shadow-xs hover:border-primary/40 transition-all duration-150 space-y-2.5">
+      {/* Header: Room Name & Status */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-semibold text-base text-foreground tracking-tight">
+              {isAcademic ? `Room ${roomNumber}` : roomNumber}
+            </span>
+            {roomResult.matchHighlight && (
+              <span className="text-[10px] uppercase font-bold tracking-wider px-1.5 py-0.5 rounded bg-primary/10 text-primary border border-primary/20">
+                {roomResult.matchHighlight}
+              </span>
+            )}
+          </div>
+
+          {/* Building Link */}
+          <button
+            type="button"
+            onClick={handleFacilityClick}
+            className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1.5 mt-0.5 transition-colors group text-left"
+            title={`View ${facility.name}`}
+          >
+            <Building2 className="w-3.5 h-3.5 text-muted-foreground group-hover:text-primary shrink-0" />
+            <span className="truncate max-w-[200px] md:max-w-[260px] font-medium underline-offset-2 group-hover:underline">
+              {facility.name}
+            </span>
+          </button>
+        </div>
+
+        {/* Room Status Badge */}
+        <div className="shrink-0">
+          <RoomBadge status={room.status} facilityType={facilityType} />
+        </div>
+      </div>
+
+      {/* Availability / Course Status Info */}
+      <div className="text-xs space-y-1 bg-muted/30 rounded-md p-2 border border-border/40">
+        {isAcademic && academicRoom && (
+          <>
+            {room.status === RoomStatus.AVAILABLE ||
+            room.status === RoomStatus.PASSING_PERIOD ? (
+              <div className="space-y-0.5 text-muted-foreground">
+                {academicRoom.passingPeriod && (
+                  <p className="font-medium text-yellow-600 dark:text-yellow-400">
+                    Passing Period
+                  </p>
+                )}
+                {room.availableFor !== undefined && room.availableFor > 0 && (
+                  <div className="flex items-center gap-1.5 text-foreground/80">
+                    <Clock className="w-3.5 h-3.5 text-green-600 shrink-0" />
+                    <span>
+                      Available for{" "}
+                      <strong className="text-foreground">
+                        {formatDuration(room.availableFor)}
+                      </strong>
+                      {academicRoom.availableUntil && (
+                        <> (until {formatTime(academicRoom.availableUntil)})</>
+                      )}
+                    </span>
+                  </div>
+                )}
+                {academicRoom.nextClass && (
+                  <p className="text-[11px] text-muted-foreground pt-0.5 truncate">
+                    <span className="font-medium text-foreground/70">Next:</span>{" "}
+                    {academicRoom.nextClass.course} - {academicRoom.nextClass.title}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-0.5 text-muted-foreground">
+                {academicRoom.currentClass && (
+                  <p className="text-[11px] text-foreground/90 truncate">
+                    <span className="font-medium text-foreground/70">Current:</span>{" "}
+                    {academicRoom.currentClass.course} - {academicRoom.currentClass.title}
+                  </p>
+                )}
+                {academicRoom.availableAt && (
+                  <div className="flex items-center gap-1.5 text-foreground/80 pt-0.5">
+                    <Clock className="w-3.5 h-3.5 text-blue-600 shrink-0" />
+                    <span>
+                      Available at {formatTime(academicRoom.availableAt)}
+                      {room.availableFor ? ` for ${formatDuration(room.availableFor)}` : ""}
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+
+        {!isAcademic && libraryRoom && (
+          <div className="text-muted-foreground">
+            {getRoomAvailabilityMessage(libraryRoom)}
+          </div>
+        )}
+      </div>
+
+      {/* Action Buttons Row */}
+      <div className="flex items-center justify-between gap-2 pt-1">
+        <div className="flex items-center gap-2">
+          {/* Schedule Toggle Button */}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setIsScheduleOpen(!isScheduleOpen)}
+            className="h-8 text-xs font-medium gap-1.5 hover:bg-secondary"
+            aria-expanded={isScheduleOpen}
+          >
+            <Calendar className="w-3.5 h-3.5" />
+            {isScheduleOpen ? "Hide Schedule" : "View Schedule"}
+            {isScheduleOpen ? (
+              <ChevronUp className="w-3.5 h-3.5 ml-0.5" />
+            ) : (
+              <ChevronDown className="w-3.5 h-3.5 ml-0.5" />
+            )}
+          </Button>
+
+          {/* Library specific buttons: Reserve & Photo */}
+          {!isAcademic && libraryRoom && (
+            <>
+              {libraryRoom.url && (
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="h-8 text-xs font-medium gap-1.5 hover:bg-secondary"
+                >
+                  <a
+                    href={libraryRoom.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <BookOpen className="w-3.5 h-3.5" />
+                    Reserve
+                  </a>
+                </Button>
+              )}
+
+              {libraryRoom.thumbnail && (
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      title="View Room Photo"
+                    >
+                      <ImageIcon className="w-3.5 h-3.5" />
+                      <span className="sr-only">View room photo</span>
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent className="p-5">
+                    <div className="relative w-full aspect-video">
+                      {isImageLoading && (
+                        <div className="absolute inset-0 w-full h-full bg-gray-300 animate-pulse rounded-md" />
+                      )}
+                      <Image
+                        src={libraryRoom.thumbnail}
+                        alt={`${roomNumber} thumbnail`}
+                        fill
+                        className="object-cover rounded-md"
+                        sizes="(max-width: 768px) 100vw, 50vw"
+                        priority
+                        onLoadingComplete={() => setIsImageLoading(false)}
+                      />
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* View on Map/Building Button */}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleFacilityClick}
+          className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground gap-1"
+          title="Locate building"
+        >
+          <MapPin className="w-3.5 h-3.5 text-primary" />
+          <span className="hidden sm:inline">Locate</span>
+        </Button>
+      </div>
+
+      {/* Collapsible Detailed Schedule */}
+      {isScheduleOpen && (
+        <div className="pt-2 border-t border-border/60 mt-2">
+          {isAcademic ? (
+            <AcademicRoomDetailLoader
+              buildingId={facility.name}
+              roomNumber={roomNumber}
+            />
+          ) : (
+            libraryRoom && <RoomSchedule slots={libraryRoom.slots} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/RoomSearchResultCard.tsx
+++ b/src/components/RoomSearchResultCard.tsx
@@ -16,18 +16,15 @@ import {
   BookOpen,
   Image as ImageIcon,
   Clock,
-  MapPin,
 } from "lucide-react";
 import Image from "next/image";
 
 interface RoomSearchResultCardProps {
   roomResult: SearchResultRoom;
-  onBuildingClick?: (facilityId: string, type: "library" | "academic") => void;
 }
 
 export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
   roomResult,
-  onBuildingClick,
 }) => {
   const [isScheduleOpen, setIsScheduleOpen] = useState(false);
   const [isImageLoading, setIsImageLoading] = useState(true);
@@ -36,14 +33,6 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
   const isAcademic = facilityType === FacilityType.ACADEMIC;
   const academicRoom = isAcademic ? (room as AcademicRoom) : null;
   const libraryRoom = !isAcademic ? (room as LibraryRoom) : null;
-
-  const handleFacilityClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onBuildingClick?.(
-      facility.id,
-      facilityType === FacilityType.LIBRARY ? "library" : "academic",
-    );
-  };
 
   return (
     <div className="rounded-lg border border-border/80 bg-card p-3.5 shadow-xs hover:border-primary/40 transition-all duration-150 space-y-2.5">
@@ -62,17 +51,12 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
           </div>
 
           {/* Building Link */}
-          <button
-            type="button"
-            onClick={handleFacilityClick}
-            className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1.5 mt-0.5 transition-colors group text-left"
-            title={`View ${facility.name}`}
-          >
-            <Building2 className="w-3.5 h-3.5 text-muted-foreground group-hover:text-primary shrink-0" />
-            <span className="truncate max-w-[200px] md:max-w-[260px] font-medium underline-offset-2 group-hover:underline">
+          <div className="text-xs text-muted-foreground flex items-center gap-1.5 mt-0.5">
+            <Building2 className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <span className="truncate max-w-[200px] md:max-w-[260px] font-medium">
               {facility.name}
             </span>
-          </button>
+          </div>
         </div>
 
         {/* Room Status Badge */}
@@ -144,7 +128,7 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
       </div>
 
       {/* Action Buttons Row */}
-      <div className="flex items-center justify-between gap-2 pt-1">
+      <div className="flex items-center gap-2 pt-1">
         <div className="flex items-center gap-2">
           {/* Schedule Toggle Button */}
           <Button
@@ -219,19 +203,6 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
             </>
           )}
         </div>
-
-        {/* View on Map/Building Button */}
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={handleFacilityClick}
-          className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground gap-1"
-          title="Locate building"
-        >
-          <MapPin className="w-3.5 h-3.5 text-primary" />
-          <span className="hidden sm:inline">Locate</span>
-        </Button>
       </div>
 
       {/* Collapsible Detailed Schedule */}

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,0 +1,267 @@
+import React, { useState, useMemo } from "react";
+import { performSearch } from "@/utils/searchUtils";
+import { Facility, FacilityStatus } from "@/types";
+import { FilterCriteria } from "@/utils/filterUtils";
+import { RoomSearchResultCard } from "@/components/RoomSearchResultCard";
+import { BuildingSearchResultCard } from "@/components/BuildingSearchResultCard";
+import { Button } from "@/components/ui/button";
+import {
+  Building2,
+  DoorOpen,
+  Layers,
+  Search,
+  XCircle,
+  FilterX,
+} from "lucide-react";
+
+interface SearchResultsProps {
+  facilityData: FacilityStatus | null;
+  searchTerm: string;
+  filterCriteria: FilterCriteria;
+  hasActiveFilters: boolean;
+  onClearFilters: () => void;
+  onClearSearch: () => void;
+  onBuildingClick?: (facilityId: string, type: "library" | "academic") => void;
+  onOpenInAccordion?: (facilityId: string, type: "library" | "academic") => void;
+}
+
+type TabType = "all" | "rooms" | "buildings";
+
+export const SearchResults: React.FC<SearchResultsProps> = ({
+  facilityData,
+  searchTerm,
+  filterCriteria,
+  hasActiveFilters,
+  onClearFilters,
+  onClearSearch,
+  onBuildingClick,
+  onOpenInAccordion,
+}) => {
+  const [activeTab, setActiveTab] = useState<TabType>("all");
+
+  const facilitiesList = useMemo<Facility[]>(() => {
+    if (!facilityData) return [];
+    return Object.values(facilityData.facilities);
+  }, [facilityData]);
+
+  const searchResults = useMemo(() => {
+    return performSearch(
+      facilitiesList,
+      searchTerm,
+      filterCriteria,
+      hasActiveFilters,
+    );
+  }, [facilitiesList, searchTerm, filterCriteria, hasActiveFilters]);
+
+  const { buildings, rooms, totalCount } = searchResults;
+
+  return (
+    <div className="px-3 md:px-4 py-3 space-y-3.5">
+      {/* Header & Filter Tabs */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Search className="w-3.5 h-3.5 text-muted-foreground" />
+            <span>
+              <strong className="text-foreground font-semibold">{totalCount}</strong>{" "}
+              result{totalCount === 1 ? "" : "s"} for &ldquo;{searchTerm}&rdquo;
+            </span>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClearSearch}
+            className="text-xs text-muted-foreground hover:text-foreground hover:underline flex items-center gap-1 transition-colors"
+          >
+            <XCircle className="w-3.5 h-3.5" />
+            Clear
+          </button>
+        </div>
+
+        {/* Tab Pills */}
+        {totalCount > 0 && (
+          <div className="flex items-center gap-1.5 p-1 bg-muted/50 rounded-lg border border-border/50 text-xs font-medium">
+            <button
+              type="button"
+              onClick={() => setActiveTab("all")}
+              className={`flex-1 py-1 px-2 rounded-md flex items-center justify-center gap-1 transition-all ${
+                activeTab === "all"
+                  ? "bg-background text-foreground shadow-xs font-semibold"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Layers className="w-3 h-3" />
+              <span>All ({totalCount})</span>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setActiveTab("rooms")}
+              className={`flex-1 py-1 px-2 rounded-md flex items-center justify-center gap-1 transition-all ${
+                activeTab === "rooms"
+                  ? "bg-background text-foreground shadow-xs font-semibold"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <DoorOpen className="w-3 h-3" />
+              <span>Rooms ({rooms.length})</span>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setActiveTab("buildings")}
+              className={`flex-1 py-1 px-2 rounded-md flex items-center justify-center gap-1 transition-all ${
+                activeTab === "buildings"
+                  ? "bg-background text-foreground shadow-xs font-semibold"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Building2 className="w-3 h-3" />
+              <span>Buildings ({buildings.length})</span>
+            </button>
+          </div>
+        )}
+
+        {/* Active Availability Filters Indicator */}
+        {hasActiveFilters && (
+          <div className="text-[11px] bg-primary/5 text-primary-foreground border border-primary/20 rounded-md px-2.5 py-1.5 flex items-center justify-between">
+            <span className="text-foreground/80 font-medium">
+              Filtered by availability criteria
+            </span>
+            <button
+              type="button"
+              onClick={onClearFilters}
+              className="text-primary hover:underline font-semibold flex items-center gap-1"
+            >
+              <FilterX className="w-3 h-3" />
+              Clear filters
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Results List */}
+      {totalCount === 0 ? (
+        <div className="py-8 text-center space-y-3">
+          <div className="w-10 h-10 rounded-full bg-muted/60 flex items-center justify-center mx-auto text-muted-foreground">
+            <Search className="w-5 h-5" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-foreground">
+              No spots found matching &ldquo;{searchTerm}&rdquo;
+            </p>
+            <p className="text-xs text-muted-foreground max-w-xs mx-auto">
+              Try searching by room number (e.g. 1404), building name (e.g. Siebel, Grainger, CIF), or course (e.g. CS 225).
+            </p>
+          </div>
+
+          <div className="flex items-center justify-center gap-2 pt-1">
+            {hasActiveFilters && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onClearFilters}
+                className="text-xs h-8"
+              >
+                Clear Filters
+              </Button>
+            )}
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={onClearSearch}
+              className="text-xs h-8"
+            >
+              Clear Search
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {/* ALL Tab */}
+          {activeTab === "all" && (
+            <>
+              {/* Buildings Section (if any match) */}
+              {buildings.length > 0 && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider pl-1">
+                    <Building2 className="w-3.5 h-3.5 text-primary" />
+                    <span>Buildings ({buildings.length})</span>
+                  </div>
+                  <div className="space-y-2.5">
+                    {buildings.map((buildingResult) => (
+                      <BuildingSearchResultCard
+                        key={`bldg-${buildingResult.facilityId}`}
+                        buildingResult={buildingResult}
+                        onBuildingClick={onBuildingClick}
+                        onOpenInAccordion={onOpenInAccordion}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Rooms Section (if any match) */}
+              {rooms.length > 0 && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider pl-1">
+                    <DoorOpen className="w-3.5 h-3.5 text-primary" />
+                    <span>Rooms ({rooms.length})</span>
+                  </div>
+                  <div className="space-y-2.5">
+                    {rooms.map((roomResult) => (
+                      <RoomSearchResultCard
+                        key={`room-${roomResult.facilityId}-${roomResult.roomNumber}`}
+                        roomResult={roomResult}
+                        onBuildingClick={onBuildingClick}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* ROOMS Tab */}
+          {activeTab === "rooms" && (
+            <div className="space-y-2.5">
+              {rooms.length > 0 ? (
+                rooms.map((roomResult) => (
+                  <RoomSearchResultCard
+                    key={`room-tab-${roomResult.facilityId}-${roomResult.roomNumber}`}
+                    roomResult={roomResult}
+                    onBuildingClick={onBuildingClick}
+                  />
+                ))
+              ) : (
+                <p className="text-center text-xs text-muted-foreground py-6">
+                  No individual rooms matched &ldquo;{searchTerm}&rdquo;.
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* BUILDINGS Tab */}
+          {activeTab === "buildings" && (
+            <div className="space-y-2.5">
+              {buildings.length > 0 ? (
+                buildings.map((buildingResult) => (
+                  <BuildingSearchResultCard
+                    key={`bldg-tab-${buildingResult.facilityId}`}
+                    buildingResult={buildingResult}
+                    onBuildingClick={onBuildingClick}
+                    onOpenInAccordion={onOpenInAccordion}
+                  />
+                ))
+              ) : (
+                <p className="text-center text-xs text-muted-foreground py-6">
+                  No buildings matched &ldquo;{searchTerm}&rdquo;.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -21,8 +21,6 @@ interface SearchResultsProps {
   hasActiveFilters: boolean;
   onClearFilters: () => void;
   onClearSearch: () => void;
-  onBuildingClick?: (facilityId: string, type: "library" | "academic") => void;
-  onOpenInAccordion?: (facilityId: string, type: "library" | "academic") => void;
 }
 
 type TabType = "all" | "rooms" | "buildings";
@@ -34,8 +32,6 @@ export const SearchResults: React.FC<SearchResultsProps> = ({
   hasActiveFilters,
   onClearFilters,
   onClearSearch,
-  onBuildingClick,
-  onOpenInAccordion,
 }) => {
   const [activeTab, setActiveTab] = useState<TabType>("all");
 
@@ -193,8 +189,6 @@ export const SearchResults: React.FC<SearchResultsProps> = ({
                       <BuildingSearchResultCard
                         key={`bldg-${buildingResult.facilityId}`}
                         buildingResult={buildingResult}
-                        onBuildingClick={onBuildingClick}
-                        onOpenInAccordion={onOpenInAccordion}
                       />
                     ))}
                   </div>
@@ -213,7 +207,6 @@ export const SearchResults: React.FC<SearchResultsProps> = ({
                       <RoomSearchResultCard
                         key={`room-${roomResult.facilityId}-${roomResult.roomNumber}`}
                         roomResult={roomResult}
-                        onBuildingClick={onBuildingClick}
                       />
                     ))}
                   </div>
@@ -230,7 +223,6 @@ export const SearchResults: React.FC<SearchResultsProps> = ({
                   <RoomSearchResultCard
                     key={`room-tab-${roomResult.facilityId}-${roomResult.roomNumber}`}
                     roomResult={roomResult}
-                    onBuildingClick={onBuildingClick}
                   />
                 ))
               ) : (
@@ -249,8 +241,6 @@ export const SearchResults: React.FC<SearchResultsProps> = ({
                   <BuildingSearchResultCard
                     key={`bldg-tab-${buildingResult.facilityId}`}
                     buildingResult={buildingResult}
-                    onBuildingClick={onBuildingClick}
-                    onOpenInAccordion={onOpenInAccordion}
                   />
                 ))
               ) : (

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -29,14 +29,14 @@ import {
     X,
     LoaderPinwheel,
     MoreHorizontal,
+    Star,
 } from "lucide-react";
-import Fuse from "fuse.js";
 import FacilityAccordion from "@/components/FacilityAccordion";
 import DateTimeButton from "@/components/DateTimeButton";
 import { FavoritesSection } from "@/components/FavoritesSection";
 import { AddFavoritesDialog } from "@/components/AddFavoritesDialog";
-import { Star } from "lucide-react";
 import RoomFilter from "@/components/RoomFilter";
+import { SearchResults } from "@/components/SearchResults";
 import { useFavorites } from "@/hooks/useFavorites";
 import { isRoomAvailable, FilterCriteria } from "@/utils/filterUtils";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
@@ -64,7 +64,6 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     const accordionRefs = useRef<AccordionRefs>({});
     const scrollAreaRef = useRef<HTMLDivElement | null>(null);
     const [searchTerm, setSearchTerm] = useState("");
-    const [searchMode, setSearchMode] = useState<"facilities" | "rooms">("facilities");
     const { favorites, toggleFavorite } = useFavorites();
     const { selectedDateTime } = useDateTimeContext();
 
@@ -84,6 +83,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     );
 
     const hasActiveFilters = !!minDuration || !!freeUntil || !!startTime;
+    const isSearching = searchTerm.trim().length > 0;
 
     const scrollToAccordion = useCallback((accordionId: string) => {
         const element = accordionRefs.current[accordionId];
@@ -116,42 +116,18 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
         prevExpandedItemsRef.current = expandedItems;
     }, [expandedItems, scrollToAccordion]);
 
-    const filterFacilities = useCallback(
+    const filterFacilitiesByAvailability = useCallback(
         (facilities: Facility[]) => {
-            let filtered = facilities;
-
-            // 1. Filter by availability criteria first (if any)
-            if (hasActiveFilters) {
-                filtered = filtered.filter((facility) => {
-                    // Check if facility has ANY room that matches the criteria
-                    return Object.values(facility.rooms).some((room) =>
-                        isRoomAvailable(room, filterCriteria),
-                    );
-                });
+            if (!hasActiveFilters) {
+                return facilities;
             }
-
-            // 2. Filter by search term
-            if (!searchTerm) {
-                return filtered;
-            }
-
-            if (searchMode === "facilities") {
-                const fuse = new Fuse(filtered, {
-                    keys: ["name"],
-                    threshold: 0.3,
-                    ignoreLocation: true,
-                });
-                return fuse.search(searchTerm).map((result) => result.item);
-            } else {
-                // Search by room names - return facilities that have matching rooms
-                return filtered.filter((facility) =>
-                    Object.keys(facility.rooms).some((roomId) =>
-                        roomId.toLowerCase().includes(searchTerm.toLowerCase()),
-                    ),
+            return facilities.filter((facility) => {
+                return Object.values(facility.rooms).some((room) =>
+                    isRoomAvailable(room, filterCriteria),
                 );
-            }
+            });
         },
-        [searchTerm, searchMode, hasActiveFilters, filterCriteria],
+        [hasActiveFilters, filterCriteria],
     );
 
     const libraryFacilities = useMemo(() => {
@@ -160,8 +136,8 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                 .filter((facility) => facility.type === FacilityType.LIBRARY)
                 .sort((a, b) => a.name.localeCompare(b.name))
             : [];
-        return filterFacilities(allLibraries);
-    }, [facilityData, filterFacilities]);
+        return filterFacilitiesByAvailability(allLibraries);
+    }, [facilityData, filterFacilitiesByAvailability]);
 
     const academicFacilities = useMemo(() => {
         const allAcademic = facilityData
@@ -169,8 +145,8 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                 .filter((facility) => facility.type === FacilityType.ACADEMIC)
                 .sort((a, b) => a.name.localeCompare(b.name))
             : [];
-        return filterFacilities(allAcademic);
-    }, [facilityData, filterFacilities]);
+        return filterFacilitiesByAvailability(allAcademic);
+    }, [facilityData, filterFacilitiesByAvailability]);
 
     const handleFavoriteClick = useCallback(
         (facilityId: string, type: "library" | "academic") => {
@@ -186,6 +162,17 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
             scrollToAccordion(accordionId);
         },
         [expandedItems, setExpandedItems, scrollToAccordion],
+    );
+
+    const handleOpenInAccordion = useCallback(
+        (facilityId: string, type: "library" | "academic") => {
+            setSearchTerm("");
+            // Use setTimeout to ensure accordion list is rendered before scrolling/expanding
+            setTimeout(() => {
+                handleFavoriteClick(facilityId, type);
+            }, 50);
+        },
+        [handleFavoriteClick],
     );
 
     const matchingRoomsCount = useMemo(() => {
@@ -229,9 +216,9 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                 type="text"
                                 value={searchTerm}
                                 onChange={(e) => setSearchTerm(e.target.value)}
-                                placeholder="Search"
+                                placeholder="Search buildings & rooms..."
                                 className={`pl-8 ${searchTerm ? "pr-8" : ""} h-9 md:h-9 rounded-full text-sm`}
-                                aria-label={searchMode === "facilities" ? "Search buildings" : "Search rooms"}
+                                aria-label="Search buildings and rooms"
                             />
                             {searchTerm && (
                                 <button
@@ -253,8 +240,6 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                             hasActiveFilters={hasActiveFilters}
                             onClearAll={clearFilters}
                             matchingRoomsCount={matchingRoomsCount}
-                            searchMode={searchMode}
-                            setSearchMode={setSearchMode}
                         />
                         <DateTimeButton isFetching={isFetching} />
                         <Popover>
@@ -365,99 +350,114 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                 className="flex-1 relative"
                 ref={scrollAreaRef}
             >
-                {" "}
-                <FavoritesSection
-                    favorites={favorites}
-                    facilityData={facilityData}
-                    onFavoriteClick={handleFavoriteClick}
-                    onToggleFavorite={toggleFavorite}
-                />
-                {libraryFacilities.length > 0 ? (
-                    <div className="mt-2">
-                        <h2 className="text-sm font-normal text-muted-foreground pl-6">
-                            Library
-                        </h2>
-                        <Accordion type="multiple" value={expandedItems} className="w-full">
-                            {libraryFacilities.map((facility) => (
-                                <FacilityAccordion
-                                    key={`library-${facility.id}`}
-                                    facility={facility}
-                                    facilityType={FacilityType.LIBRARY}
-                                    expandedItems={expandedItems}
-                                    toggleItem={toggleItem}
-                                    accordionRefs={accordionRefs}
-                                    idPrefix="library"
-                                    // onToggleFavorite removed
-                                    filterCriteria={filterCriteria}
-                                />
-                            ))}
-                        </Accordion>
-                    </div>
-                ) : isLibraryFetching && !searchTerm && !hasActiveFilters ? (
-                    <div
-                        className="mt-2"
-                        role="status"
-                        aria-busy="true"
-                        aria-label="Loading library availability"
-                    >
-                        <h2 className="text-sm font-normal text-muted-foreground pl-6">
-                            Library
-                        </h2>
-                        <span className="sr-only">Loading library availability…</span>
-                        <div aria-hidden="true">
-                            {[0, 1, 2].map((index) => (
-                                <div key={index} className="border-b">
-                                    <div className="h-[38px] px-4 flex items-center justify-between">
-                                        <div
-                                            className={`h-4 rounded bg-muted animate-pulse ${
-                                                index === 0
-                                                    ? "w-44"
-                                                    : index === 1
-                                                      ? "w-32"
-                                                      : "w-28"
-                                            }`}
+                {isSearching ? (
+                    <SearchResults
+                        facilityData={facilityData}
+                        searchTerm={searchTerm}
+                        filterCriteria={filterCriteria}
+                        hasActiveFilters={hasActiveFilters}
+                        onClearFilters={clearFilters}
+                        onClearSearch={() => setSearchTerm("")}
+                        onBuildingClick={handleFavoriteClick}
+                        onOpenInAccordion={handleOpenInAccordion}
+                    />
+                ) : (
+                    <>
+                        <FavoritesSection
+                            favorites={favorites}
+                            facilityData={facilityData}
+                            onFavoriteClick={handleFavoriteClick}
+                            onToggleFavorite={toggleFavorite}
+                        />
+                        {libraryFacilities.length > 0 ? (
+                            <div className="mt-2">
+                                <h2 className="text-sm font-normal text-muted-foreground pl-6">
+                                    Library
+                                </h2>
+                                <Accordion type="multiple" value={expandedItems} className="w-full">
+                                    {libraryFacilities.map((facility) => (
+                                        <FacilityAccordion
+                                            key={`library-${facility.id}`}
+                                            facility={facility}
+                                            facilityType={FacilityType.LIBRARY}
+                                            expandedItems={expandedItems}
+                                            toggleItem={toggleItem}
+                                            accordionRefs={accordionRefs}
+                                            idPrefix="library"
+                                            filterCriteria={filterCriteria}
                                         />
-                                        <div className="flex items-center gap-3">
-                                            <div className="h-[22px] w-12 rounded-full bg-muted animate-pulse" />
-                                            <div className="h-4 w-4 rounded bg-muted animate-pulse" />
+                                    ))}
+                                </Accordion>
+                            </div>
+                        ) : isLibraryFetching && !hasActiveFilters ? (
+                            <div
+                                className="mt-2"
+                                role="status"
+                                aria-busy="true"
+                                aria-label="Loading library availability"
+                            >
+                                <h2 className="text-sm font-normal text-muted-foreground pl-6">
+                                    Library
+                                </h2>
+                                <span className="sr-only">Loading library availability…</span>
+                                <div aria-hidden="true">
+                                    {[0, 1, 2].map((index) => (
+                                        <div key={index} className="border-b">
+                                            <div className="h-[38px] px-4 flex items-center justify-between">
+                                                <div
+                                                    className={`h-4 rounded bg-muted animate-pulse ${
+                                                        index === 0
+                                                            ? "w-44"
+                                                            : index === 1
+                                                              ? "w-32"
+                                                              : "w-28"
+                                                    }`}
+                                                />
+                                                <div className="flex items-center gap-3">
+                                                    <div className="h-[22px] w-12 rounded-full bg-muted animate-pulse" />
+                                                    <div className="h-4 w-4 rounded bg-muted animate-pulse" />
+                                                </div>
+                                            </div>
                                         </div>
-                                    </div>
+                                    ))}
                                 </div>
-                            ))}
-                        </div>
-                    </div>
-                ) : searchTerm && academicFacilities.length === 0 ? null : null}
-                {/* Academic Buildings Section */}
-                {academicFacilities.length > 0 ? (
-                    <div className="mt-5">
-                        <h2 className="text-sm font-normal text-muted-foreground pl-6">
-                            Academic
-                        </h2>
-                        <Accordion type="multiple" value={expandedItems} className="w-full">
-                            {academicFacilities.map((facility) => (
-                                <FacilityAccordion
-                                    key={`building-${facility.id}`}
-                                    facility={facility}
-                                    facilityType={FacilityType.ACADEMIC}
-                                    expandedItems={expandedItems}
-                                    toggleItem={toggleItem}
-                                    accordionRefs={accordionRefs}
-                                    idPrefix="building"
-                                    filterCriteria={filterCriteria}
-                                />
-                            ))}
-                        </Accordion>
-                    </div>
-                ) : searchTerm && libraryFacilities.length === 0 ? null : null}
-                {/* No Results Message */}
-                {(searchTerm || hasActiveFilters) &&
-                    libraryFacilities.length === 0 &&
-                    academicFacilities.length === 0 && (
-                        <p className="text-center text-muted-foreground text-sm mt-6 px-4">
-                            No results found matching your criteria
-                        </p>
-                    )}
-                <div className="h-4"></div>
+                            </div>
+                        ) : null}
+
+                        {/* Academic Buildings Section */}
+                        {academicFacilities.length > 0 && (
+                            <div className="mt-5">
+                                <h2 className="text-sm font-normal text-muted-foreground pl-6">
+                                    Academic
+                                </h2>
+                                <Accordion type="multiple" value={expandedItems} className="w-full">
+                                    {academicFacilities.map((facility) => (
+                                        <FacilityAccordion
+                                            key={`building-${facility.id}`}
+                                            facility={facility}
+                                            facilityType={FacilityType.ACADEMIC}
+                                            expandedItems={expandedItems}
+                                            toggleItem={toggleItem}
+                                            accordionRefs={accordionRefs}
+                                            idPrefix="building"
+                                            filterCriteria={filterCriteria}
+                                        />
+                                    ))}
+                                </Accordion>
+                            </div>
+                        )}
+
+                        {/* No Results Message for active filters */}
+                        {hasActiveFilters &&
+                            libraryFacilities.length === 0 &&
+                            academicFacilities.length === 0 && (
+                                <p className="text-center text-muted-foreground text-sm mt-6 px-4">
+                                    No results found matching your criteria
+                                </p>
+                            )}
+                        <div className="h-4"></div>
+                    </>
+                )}
             </ScrollArea>
 
             {/* Dimming Overlay*/}

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -164,17 +164,6 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
         [expandedItems, setExpandedItems, scrollToAccordion],
     );
 
-    const handleOpenInAccordion = useCallback(
-        (facilityId: string, type: "library" | "academic") => {
-            setSearchTerm("");
-            // Use setTimeout to ensure accordion list is rendered before scrolling/expanding
-            setTimeout(() => {
-                handleFavoriteClick(facilityId, type);
-            }, 50);
-        },
-        [handleFavoriteClick],
-    );
-
     const matchingRoomsCount = useMemo(() => {
         const allFacilities = facilityData
             ? Object.values(facilityData.facilities)
@@ -358,8 +347,6 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                         hasActiveFilters={hasActiveFilters}
                         onClearFilters={clearFilters}
                         onClearSearch={() => setSearchTerm("")}
-                        onBuildingClick={handleFavoriteClick}
-                        onOpenInAccordion={handleOpenInAccordion}
                     />
                 ) : (
                     <>

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -1,0 +1,462 @@
+import { Facility, FacilityRoom, FacilityType, RoomStatus, AcademicRoom, LibraryRoom } from "@/types";
+import { FilterCriteria, isRoomAvailable } from "@/utils/filterUtils";
+import Fuse from "fuse.js";
+
+export const BUILDING_ALIASES: Record<string, string[]> = {
+  "Campus Instructional Facility": ["cif", "campus instructional", "instructional facility"],
+  "Business Instructional Facility": ["bif", "business instructional"],
+  "Electrical and Computer Engineering Building": ["eceb", "ece", "electrical engineering", "computer engineering"],
+  "Siebel Center for Comp Sci": ["siebel", "sc", "cs", "siebel cs", "siebel center", "computer science"],
+  "Thomas M. Siebel Center for Computer Science": ["siebel", "sc", "cs", "siebel cs", "siebel center", "computer science"],
+  "Siebel Center for Design": ["scd", "design"],
+  "Digital Computer Laboratory": ["dcl"],
+  "Sidney Lu Mechanical Engr Bldg": ["mel", "meb", "mech", "sidney lu", "mechanical"],
+  "Mechanical Engineering Building": ["meb", "mech", "mechanical"],
+  "Mechanical Engineering Laboratory": ["mel", "mech", "mechanical lab"],
+  "Natural History Building": ["nhb", "natural history"],
+  "David Kinley Hall": ["dkh", "kinley"],
+  "Transportation Building": ["tb", "transportation"],
+  "Coordinated Science Laboratory": ["csl", "coordinated science"],
+  "Literatures, Cultures, and Linguistics Building": ["lclb", "literatures", "linguistics", "foreign languages"],
+  "Literatures, Cultures, & Ling": ["lclb", "literatures", "linguistics", "foreign languages"],
+  "Loomis Laboratory of Physics": ["loomis", "physics"],
+  "Noyes Laboratory": ["noyes", "chemistry", "chem"],
+  "Materials Science & Eng Bld": ["mseb", "matse", "materials science"],
+  "Material Science and Engineering Building": ["mseb", "matse", "materials science"],
+  "Agricultural Engr Sciences Bld": ["aesb", "agricultural", "aces bldg"],
+  "Grainger Engineering Library": ["grainger", "gel", "grainger library", "engineering library"],
+  "Funk ACES Library": ["aces", "funk", "funk library", "aces library", "funk aces"],
+  "Main Library": ["main", "main library", "orange room", "media commons", "the orange room"],
+  "Chemistry Annex": ["chem annex", "chemistry annex"],
+  "Henry Administration Bldg": ["hab", "henry"],
+  "Wohlers Hall": ["wohlers"],
+  "Mumford Hall": ["mumford"],
+  "Flagg Hall": ["flagg"],
+  "Everitt Laboratory": ["everitt", "bioengineering", "bioe"],
+  "Engineering Hall": ["engr hall", "engineering hall"],
+  "English Building": ["english"],
+  "Davenport Hall": ["davenport"],
+  "Burrill Hall": ["burrill"],
+  "Bevier Hall": ["bevier"],
+  "Armory": ["armory"],
+  "Art and Design Building": ["art & design", "art and design", "art"],
+  "Architecture Building": ["arch", "architecture"],
+  "Psychology Building": ["psych", "psychology"],
+  "Newmark Civil Engineering Bldg": ["newmark", "cee", "civil"],
+  "Civil & Envir Eng Bldg": ["cee", "hydro", "civil"],
+  "Turner Hall": ["turner"],
+  "Wymer Hall": ["wymer"],
+};
+
+export interface SearchResultRoom {
+  type: "room";
+  roomNumber: string;
+  facilityId: string;
+  facilityName: string;
+  facilityType: FacilityType;
+  room: FacilityRoom;
+  facility: Facility;
+  score: number;
+  matchHighlight?: string;
+}
+
+export interface SearchResultBuilding {
+  type: "building";
+  facilityId: string;
+  facilityName: string;
+  facilityType: FacilityType;
+  facility: Facility;
+  score: number;
+  availableRoomsCount: number;
+  totalRoomsCount: number;
+  matchingRooms: SearchResultRoom[];
+}
+
+export interface SearchResultsData {
+  buildings: SearchResultBuilding[];
+  rooms: SearchResultRoom[];
+  totalCount: number;
+}
+
+/**
+ * Generates automated acronyms and aliases for a building name
+ */
+export const getBuildingAliases = (buildingName: string): string[] => {
+  const custom = BUILDING_ALIASES[buildingName] || [];
+  const words = buildingName
+    .replace(/[^\w\s]/g, "")
+    .split(/\s+/)
+    .filter(Boolean);
+
+  const aliases = new Set<string>(custom.map((a) => a.toLowerCase()));
+
+  // Add lowercase full name
+  aliases.add(buildingName.toLowerCase());
+
+  // Generate acronym from initials (e.g., Campus Instructional Facility -> cif)
+  if (words.length > 1) {
+    const acronym = words
+      .map((w) => w[0])
+      .join("")
+      .toLowerCase();
+    if (acronym.length >= 2) {
+      aliases.add(acronym);
+    }
+  }
+
+  return Array.from(aliases);
+};
+
+const getStatusRank = (status: RoomStatus): number => {
+  switch (status) {
+    case RoomStatus.AVAILABLE:
+      return 5;
+    case RoomStatus.PASSING_PERIOD:
+      return 4;
+    case RoomStatus.OPENING_SOON:
+      return 3;
+    case RoomStatus.OCCUPIED:
+      return 2;
+    case RoomStatus.RESERVED:
+      return 1;
+    case RoomStatus.UNAVAILABLE:
+    default:
+      return 0;
+  }
+};
+
+/**
+ * Searches across facilities (buildings) and rooms.
+ */
+export const performSearch = (
+  facilities: Facility[],
+  searchTerm: string,
+  filterCriteria: FilterCriteria = {},
+  hasActiveFilters: boolean = false,
+): SearchResultsData => {
+  const query = searchTerm.trim().toLowerCase();
+  if (!query) {
+    return { buildings: [], rooms: [], totalCount: 0 };
+  }
+
+  const queryTokens = query.split(/\s+/).filter(Boolean);
+  const cleanTokens = queryTokens.filter(
+    (t) => !["room", "rm", "bldg", "building"].includes(t),
+  );
+  const effectiveTokens = cleanTokens.length > 0 ? cleanTokens : queryTokens;
+
+  const buildingResults: SearchResultBuilding[] = [];
+
+  // Prepare searchable items
+  interface RoomSearchItem {
+    roomNumber: string;
+    facilityId: string;
+    facilityName: string;
+    facilityType: FacilityType;
+    room: FacilityRoom;
+    facility: Facility;
+    aliases: string[];
+    courseInfo: string;
+    groupingInfo: string;
+    searchableString: string;
+  }
+
+  const roomItems: RoomSearchItem[] = [];
+
+  facilities.forEach((facility) => {
+    const aliases = getBuildingAliases(facility.name);
+    const facilityNameLower = facility.name.toLowerCase();
+
+    // 1. Evaluate Building Match
+    let buildingScore = 0;
+
+    // Check exact or substring matches in building name or aliases
+    if (facilityNameLower === query || aliases.includes(query)) {
+      buildingScore = 1.0;
+    } else if (
+      facilityNameLower.startsWith(query) ||
+      aliases.some((a) => a.startsWith(query))
+    ) {
+      buildingScore = 0.92;
+    } else if (
+      facilityNameLower.includes(query) ||
+      aliases.some((a) => a.includes(query))
+    ) {
+      buildingScore = 0.85;
+    } else {
+      // Check token-level matches
+      const matchedTokens = effectiveTokens.filter(
+        (token) =>
+          facilityNameLower.includes(token) ||
+          aliases.some((a) => a.includes(token) || token.includes(a)),
+      );
+      if (matchedTokens.length === effectiveTokens.length) {
+        buildingScore = 0.8;
+      } else if (matchedTokens.length > 0) {
+        buildingScore = 0.4 + 0.35 * (matchedTokens.length / effectiveTokens.length);
+      }
+    }
+
+    // Calculate room counts with filters
+    const availableRoomsCount = Object.values(facility.rooms).filter((room) => {
+      const isAvail =
+        room.status === RoomStatus.AVAILABLE ||
+        room.status === RoomStatus.PASSING_PERIOD;
+      return hasActiveFilters ? isAvail && isRoomAvailable(room, filterCriteria) : isAvail;
+    }).length;
+
+    const totalRoomsCount = facility.roomCounts?.total ?? Object.keys(facility.rooms).length;
+
+    // 2. Prepare Room Items
+    Object.entries(facility.rooms).forEach(([roomNumber, room]) => {
+      // If active filters are set, skip rooms that don't match availability criteria
+      if (hasActiveFilters && !isRoomAvailable(room, filterCriteria)) {
+        return;
+      }
+
+      let courseInfo = "";
+      let groupingInfo = "";
+
+      if (room.type === "academic") {
+        const acad = room as AcademicRoom;
+        if (acad.currentClass) {
+          courseInfo += ` ${acad.currentClass.course} ${acad.currentClass.title}`;
+        }
+        if (acad.nextClass) {
+          courseInfo += ` ${acad.nextClass.course} ${acad.nextClass.title}`;
+        }
+      } else if (room.type === "library") {
+        const lib = room as LibraryRoom;
+        if ((lib as any).grouping) {
+          groupingInfo += ` ${(lib as any).grouping}`;
+        }
+      }
+
+      const searchableString = `${facility.name} ${aliases.join(
+        " ",
+      )} ${roomNumber} room ${roomNumber} ${courseInfo} ${groupingInfo}`.toLowerCase();
+
+      roomItems.push({
+        roomNumber,
+        facilityId: facility.id,
+        facilityName: facility.name,
+        facilityType: facility.type,
+        room,
+        facility,
+        aliases,
+        courseInfo: courseInfo.toLowerCase(),
+        groupingInfo: groupingInfo.toLowerCase(),
+        searchableString,
+      });
+    });
+
+    if (buildingScore >= 0.4) {
+      buildingResults.push({
+        type: "building",
+        facilityId: facility.id,
+        facilityName: facility.name,
+        facilityType: facility.type,
+        facility,
+        score: buildingScore,
+        availableRoomsCount,
+        totalRoomsCount,
+        matchingRooms: [],
+      });
+    }
+  });
+
+  // 3. Score Rooms
+  const scoredRoomsMap = new Map<string, SearchResultRoom>();
+
+  roomItems.forEach((item) => {
+    const roomNumLower = item.roomNumber.toLowerCase();
+    const facilityNameLower = item.facilityName.toLowerCase();
+    let score = 0;
+    let highlight = "";
+
+    // A. Direct room number exact match (e.g., query "1404" -> room "1404")
+    if (roomNumLower === query || `room ${roomNumLower}` === query) {
+      score = 1.0;
+      highlight = `Room ${item.roomNumber}`;
+    }
+    // B. Multi-token room + building combined query (e.g., "siebel 1404", "cif 0027", "grainger 405")
+    else if (effectiveTokens.length >= 2) {
+      const roomNumMatched = effectiveTokens.some(
+        (t) => t === roomNumLower || roomNumLower.includes(t) || t.includes(roomNumLower),
+      );
+      const buildingMatched = effectiveTokens.some(
+        (t) =>
+          facilityNameLower.includes(t) ||
+          item.aliases.some((a) => a.includes(t) || t.includes(a)),
+      );
+
+      if (roomNumMatched && buildingMatched) {
+        score = 0.98;
+        highlight = `${item.facilityName} - Room ${item.roomNumber}`;
+      } else if (roomNumMatched) {
+        score = 0.85;
+      } else if (buildingMatched) {
+        score = 0.6;
+      }
+    }
+    // C. Room number starts with query or contains query (e.g., "140" -> "1404")
+    else if (roomNumLower.startsWith(query)) {
+      score = 0.92;
+    } else if (roomNumLower.includes(query)) {
+      score = 0.82;
+    }
+    // D. Building name match (e.g., user searched "siebel" -> include rooms in Siebel)
+    else if (
+      facilityNameLower.includes(query) ||
+      item.aliases.some((a) => a.includes(query))
+    ) {
+      score = 0.65;
+    }
+    // E. Course info or grouping info match (e.g., "cs 225", "orange room")
+    else if (item.courseInfo.includes(query)) {
+      score = 0.9;
+      highlight = "Course match";
+    } else if (item.groupingInfo.includes(query)) {
+      score = 0.88;
+      highlight = "Location match";
+    }
+
+    // Boost score slightly if room is available
+    if (
+      item.room.status === RoomStatus.AVAILABLE ||
+      item.room.status === RoomStatus.PASSING_PERIOD
+    ) {
+      score += 0.03;
+    }
+
+    if (score >= 0.5) {
+      const key = `${item.facilityId}-${item.roomNumber}`;
+      scoredRoomsMap.set(key, {
+        type: "room",
+        roomNumber: item.roomNumber,
+        facilityId: item.facilityId,
+        facilityName: item.facilityName,
+        facilityType: item.facilityType,
+        room: item.room,
+        facility: item.facility,
+        score,
+        matchHighlight: highlight,
+      });
+    }
+  });
+
+  // 4. Fallback Fuzzy Search with Fuse.js for typos if few direct results
+  if (scoredRoomsMap.size < 5) {
+    const fuse = new Fuse(roomItems, {
+      keys: [
+        { name: "roomNumber", weight: 0.6 },
+        { name: "facilityName", weight: 0.25 },
+        { name: "aliases", weight: 0.2 },
+        { name: "courseInfo", weight: 0.2 },
+      ],
+      threshold: 0.4,
+      ignoreLocation: true,
+      minMatchCharLength: 2,
+    });
+
+    const fuseResults = fuse.search(query);
+    fuseResults.forEach((res) => {
+      const item = res.item;
+      const key = `${item.facilityId}-${item.roomNumber}`;
+      if (!scoredRoomsMap.has(key)) {
+        const fuzzyScore = Math.max(0.45, 1 - (res.score ?? 0.5) * 0.7);
+        scoredRoomsMap.set(key, {
+          type: "room",
+          roomNumber: item.roomNumber,
+          facilityId: item.facilityId,
+          facilityName: item.facilityName,
+          facilityType: item.facilityType,
+          room: item.room,
+          facility: item.facility,
+          score: fuzzyScore,
+        });
+      }
+    });
+  }
+
+  // 5. Fallback Fuzzy Search for Buildings if few direct building results
+  if (buildingResults.length < 2) {
+    const fuseBuildings = new Fuse(facilities, {
+      keys: [
+        { name: "name", weight: 0.7 },
+        { name: "id", weight: 0.3 },
+      ],
+      threshold: 0.4,
+      ignoreLocation: true,
+      minMatchCharLength: 2,
+    });
+
+    const fuseBuildingResults = fuseBuildings.search(query);
+    fuseBuildingResults.forEach((res) => {
+      const facility = res.item;
+      if (!buildingResults.some((b) => b.facilityId === facility.id)) {
+        const availableRoomsCount = Object.values(facility.rooms).filter((room) => {
+          const isAvail =
+            room.status === RoomStatus.AVAILABLE ||
+            room.status === RoomStatus.PASSING_PERIOD;
+          return hasActiveFilters ? isAvail && isRoomAvailable(room, filterCriteria) : isAvail;
+        }).length;
+        const totalRoomsCount = facility.roomCounts?.total ?? Object.keys(facility.rooms).length;
+
+        buildingResults.push({
+          type: "building",
+          facilityId: facility.id,
+          facilityName: facility.name,
+          facilityType: facility.type,
+          facility,
+          score: Math.max(0.45, 1 - (res.score ?? 0.5) * 0.7),
+          availableRoomsCount,
+          totalRoomsCount,
+          matchingRooms: [],
+        });
+      }
+    });
+  }
+
+  // Convert room map to array and sort
+  const allRooms = Array.from(scoredRoomsMap.values()).sort((a, b) => {
+    // Primary: Score
+    if (Math.abs(b.score - a.score) > 0.08) {
+      return b.score - a.score;
+    }
+    // Secondary: Status Rank (Available first)
+    const rankDiff = getStatusRank(b.room.status) - getStatusRank(a.room.status);
+    if (rankDiff !== 0) return rankDiff;
+
+    // Tertiary: Room Number alphanumeric sort
+    return a.roomNumber.localeCompare(b.roomNumber, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    });
+  });
+
+  // Sort building results
+  buildingResults.sort((a, b) => {
+    if (Math.abs(b.score - a.score) > 0.1) {
+      return b.score - a.score;
+    }
+    if (a.facility.isOpen !== b.facility.isOpen) {
+      return a.facility.isOpen ? -1 : 1;
+    }
+    if (b.availableRoomsCount !== a.availableRoomsCount) {
+      return b.availableRoomsCount - a.availableRoomsCount;
+    }
+    return a.facilityName.localeCompare(b.facilityName);
+  });
+
+  // Attach matching rooms to building results for rich preview
+  buildingResults.forEach((b) => {
+    b.matchingRooms = allRooms.filter((r) => r.facilityId === b.facilityId);
+  });
+
+  return {
+    buildings: buildingResults,
+    rooms: allRooms,
+    totalCount: buildingResults.length + allRooms.length,
+  };
+};

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -162,6 +162,16 @@ export const performSearch = (
   }
 
   const roomItems: RoomSearchItem[] = [];
+  const toSearchResultRoom = (item: RoomSearchItem): SearchResultRoom => ({
+    type: "room",
+    roomNumber: item.roomNumber,
+    facilityId: item.facilityId,
+    facilityName: item.facilityName,
+    facilityType: item.facilityType,
+    room: item.room,
+    facility: item.facility,
+    score: 0.5,
+  });
 
   facilities.forEach((facility) => {
     const aliases = getBuildingAliases(facility.name);
@@ -454,9 +464,23 @@ export const performSearch = (
     return a.facilityName.localeCompare(b.facilityName);
   });
 
+  // Keep a filtered room fallback for building cards. The room fuzzy search
+  // can be skipped once enough direct room matches exist, but a fuzzy building
+  // result still needs rooms that satisfy the active availability filters.
+  const eligibleRoomsByFacility = new Map<string, SearchResultRoom[]>();
+  roomItems.forEach((item) => {
+    const rooms = eligibleRoomsByFacility.get(item.facilityId) ?? [];
+    rooms.push(toSearchResultRoom(item));
+    eligibleRoomsByFacility.set(item.facilityId, rooms);
+  });
+
   // Attach matching rooms to building results for rich preview
   buildingResults.forEach((b) => {
-    b.matchingRooms = allRooms.filter((r) => r.facilityId === b.facilityId);
+    const matchingRooms = allRooms.filter((r) => r.facilityId === b.facilityId);
+    b.matchingRooms =
+      matchingRooms.length > 0 || !hasActiveFilters
+        ? matchingRooms
+        : eligibleRoomsByFacility.get(b.facilityId) ?? [];
   });
 
   return {

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -250,7 +250,10 @@ export const performSearch = (
       });
     });
 
-    if (buildingScore >= 0.4) {
+    // Do not return a building that has no rooms matching the active
+    // availability filters. Otherwise its card falls back to rendering all
+    // facility rooms, including rooms that were filtered out.
+    if (buildingScore >= 0.4 && (!hasActiveFilters || availableRoomsCount > 0)) {
       buildingResults.push({
         type: "building",
         facilityId: facility.id,
@@ -403,17 +406,19 @@ export const performSearch = (
         }).length;
         const totalRoomsCount = facility.roomCounts?.total ?? Object.keys(facility.rooms).length;
 
-        buildingResults.push({
-          type: "building",
-          facilityId: facility.id,
-          facilityName: facility.name,
-          facilityType: facility.type,
-          facility,
-          score: Math.max(0.45, 1 - (res.score ?? 0.5) * 0.7),
-          availableRoomsCount,
-          totalRoomsCount,
-          matchingRooms: [],
-        });
+        if (!hasActiveFilters || availableRoomsCount > 0) {
+          buildingResults.push({
+            type: "building",
+            facilityId: facility.id,
+            facilityName: facility.name,
+            facilityType: facility.type,
+            facility,
+            score: Math.max(0.45, 1 - (res.score ?? 0.5) * 0.7),
+            availableRoomsCount,
+            totalRoomsCount,
+            matchingRooms: [],
+          });
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- add unified building and room search with aliases, room/course matching, and fuzzy fallback
- add tabbed search results with building and room detail cards
- preserve availability filters and connect search results to map/list actions

## Validation
- npm run lint
- npm run build (Vercel preview)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified search for buildings and rooms with fuzzy matching, aliases, course references, and relevance-based results.
  * Added dedicated building and room result cards with availability, hours, status, schedules, actions, and navigation options.
  * Added All, Rooms, and Buildings result views with result counts and empty states.
  * Added availability filtering, clear-search controls, room expansion, building location, reservations, and photo actions.
* **Improvements**
  * Streamlined search controls by removing the separate facility/room search-mode selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces unified building and room search while preserving availability-filter behavior.
- Adds alias, room-number, course, grouping, and fuzzy matching in a shared search utility.
- Adds tabbed building and room results with expandable room and schedule details.
- Replaces the sidebar’s separate building/room search modes with unified search results.
- Ensures direct and fuzzy building previews use rooms eligible under active availability filters.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/searchUtils.ts | Implements unified relevance scoring, aliases, fuzzy fallbacks, and availability-safe building room previews. |
| src/components/SearchResults.tsx | Renders unified results across All, Rooms, and Buildings tabs with filter and empty-state controls. |
| src/components/BuildingSearchResultCard.tsx | Adds building details and expandable room previews sourced from the search result. |
| src/components/RoomSearchResultCard.tsx | Adds room availability, reservation, image, and expandable schedule presentation. |
| src/components/left.tsx | Integrates unified search into the sidebar while retaining the ordinary filtered accordion view outside searches. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Search term and availability filters] --> B[performSearch]
    B --> C[Score direct building matches]
    B --> D[Filter and score room matches]
    C --> E[Fuzzy building fallback]
    D --> F[Fuzzy room fallback]
    E --> G[Attach eligible room previews]
    F --> G
    G --> H[Tabbed SearchResults]
    H --> I[Building result cards]
    H --> J[Room result cards]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Keep filtered rooms for fuzzy building m..."](https://github.com/plon/illinispots/commit/6ffda51461aff821e342abc17f455c9e4fc65308) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54929856)</sub>

<!-- /greptile_comment -->