### PR TITLE
Precompute normalized room availability segments

### DIFF
--- a/supabase/migrations/20260819000600_cache_normalized_room_segments.sql
+++ b/supabase/migrations/20260819000600_cache_normalized_room_segments.sql
@@ -1,0 +1,336 @@
+-- Materialize intervals where a room's occupancy and activity metadata are
+-- stable. The API's 30-minute hot path can then perform a point lookup instead
+-- of expanding and ranking every cached activity on each request.
+CREATE TABLE public.room_availability_cache_segments (
+    check_date DATE NOT NULL,
+    building_name TEXT NOT NULL,
+    room_number TEXT NOT NULL,
+    segment_start TIME NOT NULL,
+    segment_end TIME NOT NULL,
+    is_occupied BOOLEAN NOT NULL,
+    current_activity JSONB,
+    next_activity JSONB,
+    next_start_time TIME,
+    meaningful_available_at TIME,
+    next_island_start TIME,
+    PRIMARY KEY (
+        check_date,
+        building_name,
+        room_number,
+        segment_start
+    ),
+    CONSTRAINT room_availability_cache_segments_valid_time
+        CHECK (segment_start < segment_end),
+    CONSTRAINT room_availability_cache_segments_room_fkey
+        FOREIGN KEY (building_name, room_number, check_date)
+        REFERENCES public.room_availability_cache (
+            building_name,
+            room_number,
+            check_date
+        )
+        ON DELETE CASCADE
+);
+
+ALTER TABLE public.room_availability_cache_segments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY room_availability_cache_segments_public_read
+    ON public.room_availability_cache_segments
+    FOR SELECT
+    TO anon, authenticated
+    USING (true);
+
+REVOKE ALL ON TABLE public.room_availability_cache_segments FROM PUBLIC;
+GRANT SELECT ON TABLE public.room_availability_cache_segments
+TO anon, authenticated;
+GRANT SELECT, INSERT, DELETE ON TABLE public.room_availability_cache_segments
+TO service_role;
+
+CREATE OR REPLACE FUNCTION public.refresh_room_availability_cache_segments(
+    target_date DATE
+)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    DELETE FROM room_availability_cache_segments
+    WHERE check_date = target_date;
+
+    WITH day_hours AS MATERIALIZED (
+        SELECT
+            b.name AS building_name,
+            CASE EXTRACT(DOW FROM target_date)
+                WHEN 1 THEN b.monday_open WHEN 2 THEN b.tuesday_open
+                WHEN 3 THEN b.wednesday_open WHEN 4 THEN b.thursday_open
+                WHEN 5 THEN b.friday_open WHEN 6 THEN b.saturday_open
+                WHEN 0 THEN b.sunday_open
+            END AS open_time,
+            CASE EXTRACT(DOW FROM target_date)
+                WHEN 1 THEN b.monday_close WHEN 2 THEN b.tuesday_close
+                WHEN 3 THEN b.wednesday_close WHEN 4 THEN b.thursday_close
+                WHEN 5 THEN b.friday_close WHEN 6 THEN b.saturday_close
+                WHEN 0 THEN b.sunday_close
+            END AS close_time
+        FROM buildings b
+    ),
+    cached_rooms AS MATERIALIZED (
+        SELECT
+            c.building_name,
+            c.room_number,
+            c.busy_times,
+            c.schedule_data,
+            dh.open_time,
+            dh.close_time
+        FROM room_availability_cache c
+        JOIN day_hours dh ON dh.building_name = c.building_name
+        WHERE c.check_date = target_date
+          AND dh.open_time IS NOT NULL
+          AND dh.close_time IS NOT NULL
+          AND dh.open_time < dh.close_time
+    ),
+    activities AS MATERIALIZED (
+        SELECT
+            cr.building_name,
+            cr.room_number,
+            activity.item,
+            activity.ordinality,
+            (activity.item->>'start')::time AS start_time,
+            (activity.item->>'end')::time AS end_time
+        FROM cached_rooms cr
+        CROSS JOIN LATERAL jsonb_array_elements(
+            COALESCE(cr.schedule_data, '[]'::jsonb)
+        ) WITH ORDINALITY AS activity(item, ordinality)
+        WHERE activity.item->>'status' IN ('class', 'event')
+    ),
+    boundaries AS MATERIALIZED (
+        SELECT
+            building_name,
+            room_number,
+            open_time AS boundary
+        FROM cached_rooms
+
+        UNION
+
+        SELECT
+            building_name,
+            room_number,
+            close_time AS boundary
+        FROM cached_rooms
+
+        UNION
+
+        SELECT
+            a.building_name,
+            a.room_number,
+            a.start_time AS boundary
+        FROM activities a
+        JOIN cached_rooms cr
+          ON cr.building_name = a.building_name
+         AND cr.room_number = a.room_number
+        WHERE a.start_time > cr.open_time
+          AND a.start_time < cr.close_time
+
+        UNION
+
+        SELECT
+            a.building_name,
+            a.room_number,
+            a.end_time AS boundary
+        FROM activities a
+        JOIN cached_rooms cr
+          ON cr.building_name = a.building_name
+         AND cr.room_number = a.room_number
+        WHERE a.end_time > cr.open_time
+          AND a.end_time < cr.close_time
+    ),
+    segments AS MATERIALIZED (
+        SELECT
+            building_name,
+            room_number,
+            boundary AS segment_start,
+            lead(boundary) OVER (
+                PARTITION BY building_name, room_number
+                ORDER BY boundary
+            ) AS segment_end
+        FROM boundaries
+    ),
+    -- Arrays compare lexicographically, preserving get_cached_spots' existing
+    -- start/end/ordinality tie-breakers while this work runs once at refresh.
+    segment_activity_ordinals AS MATERIALIZED (
+        SELECT
+            s.building_name,
+            s.room_number,
+            s.segment_start,
+            s.segment_end,
+            -(
+                max(ARRAY[
+                    EXTRACT(EPOCH FROM a.start_time)::bigint,
+                    EXTRACT(EPOCH FROM a.end_time)::bigint,
+                    -a.ordinality
+                ]) FILTER (
+                    WHERE a.start_time <= s.segment_start
+                      AND a.end_time > s.segment_start
+                )
+            )[3] AS current_ordinality,
+            (
+                min(ARRAY[
+                    EXTRACT(EPOCH FROM a.start_time)::bigint,
+                    -EXTRACT(EPOCH FROM a.end_time)::bigint,
+                    a.ordinality
+                ]) FILTER (WHERE a.start_time > s.segment_start)
+            )[3] AS next_ordinality
+        FROM segments s
+        LEFT JOIN activities a
+          ON a.building_name = s.building_name
+         AND a.room_number = s.room_number
+        WHERE s.segment_end IS NOT NULL
+          AND s.segment_start < s.segment_end
+        GROUP BY
+            s.building_name,
+            s.room_number,
+            s.segment_start,
+            s.segment_end
+    ),
+    segment_activities AS MATERIALIZED (
+        SELECT
+            sao.building_name,
+            sao.room_number,
+            sao.segment_start,
+            sao.segment_end,
+            current_activity.item AS current_activity,
+            next_activity.item AS next_activity,
+            next_activity.start_time AS next_start_time
+        FROM segment_activity_ordinals sao
+        LEFT JOIN activities current_activity
+          ON current_activity.building_name = sao.building_name
+         AND current_activity.room_number = sao.room_number
+         AND current_activity.ordinality = sao.current_ordinality
+        LEFT JOIN activities next_activity
+          ON next_activity.building_name = sao.building_name
+         AND next_activity.room_number = sao.room_number
+         AND next_activity.ordinality = sao.next_ordinality
+    ),
+    busy_ranges AS MATERIALIZED (
+        SELECT
+            cr.building_name,
+            cr.room_number,
+            upper(br.time_range)::time AS range_end,
+            lead(lower(br.time_range)::time) OVER (
+                PARTITION BY cr.building_name, cr.room_number
+                ORDER BY br.ordinality
+            ) AS next_range_start
+        FROM cached_rooms cr
+        CROSS JOIN LATERAL unnest(
+            COALESCE(cr.busy_times, '{}'::tsmultirange)
+        ) WITH ORDINALITY AS br(time_range, ordinality)
+    ),
+    -- Occupancy must use the timestamp multirange directly. Some source events
+    -- span multiple dates, so comparing only their time-of-day endpoints would
+    -- produce a different result from get_cached_spots.
+    segment_states AS MATERIALIZED (
+        SELECT
+            sa.*,
+            cr.busy_times @> (target_date + sa.segment_start) AS is_occupied,
+            meaningful.available_at,
+            meaningful.next_island_start
+        FROM segment_activities sa
+        JOIN cached_rooms cr
+          ON cr.building_name = sa.building_name
+         AND cr.room_number = sa.room_number
+        LEFT JOIN LATERAL (
+            SELECT
+                future.range_end AS available_at,
+                future.next_range_start AS next_island_start
+            FROM busy_ranges future
+            WHERE future.building_name = sa.building_name
+              AND future.room_number = sa.room_number
+              AND future.range_end > sa.segment_start
+              AND (
+                  future.next_range_start IS NULL
+                  OR future.next_range_start - future.range_end >= interval '30 minutes'
+              )
+            ORDER BY future.range_end
+            LIMIT 1
+        ) meaningful ON true
+    )
+    INSERT INTO room_availability_cache_segments (
+        check_date,
+        building_name,
+        room_number,
+        segment_start,
+        segment_end,
+        is_occupied,
+        current_activity,
+        next_activity,
+        next_start_time,
+        meaningful_available_at,
+        next_island_start
+    )
+    SELECT
+        target_date,
+        ss.building_name,
+        ss.room_number,
+        ss.segment_start,
+        ss.segment_end,
+        ss.is_occupied,
+        ss.current_activity,
+        ss.next_activity,
+        ss.next_start_time,
+        ss.available_at,
+        ss.next_island_start
+    FROM segment_states ss;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION
+    public.refresh_room_availability_cache_segments(date)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION
+    public.refresh_room_availability_cache_segments(date)
+TO service_role;
+
+CREATE OR REPLACE FUNCTION public.populate_room_availability_cache_segments()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    target_date DATE;
+BEGIN
+    FOR target_date IN
+        SELECT DISTINCT check_date
+        FROM inserted_cache_rows
+    LOOP
+        PERFORM refresh_room_availability_cache_segments(target_date);
+    END LOOP;
+
+    RETURN NULL;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION
+    public.populate_room_availability_cache_segments()
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION
+    public.populate_room_availability_cache_segments()
+TO service_role;
+
+CREATE TRIGGER populate_room_availability_cache_segments_after_insert
+AFTER INSERT ON public.room_availability_cache
+REFERENCING NEW TABLE AS inserted_cache_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.populate_room_availability_cache_segments();
+
+DO $$
+DECLARE
+    target_date DATE;
+BEGIN
+    FOR target_date IN
+        SELECT DISTINCT check_date
+        FROM room_availability_cache
+        ORDER BY check_date
+    LOOP
+        PERFORM refresh_room_availability_cache_segments(target_date);
+    END LOOP;
+END;
+$$;

--- a/supabase/migrations/20260819000700_use_normalized_room_segments.sql
+++ b/supabase/migrations/20260819000700_use_normalized_room_segments.sql
@@ -1,0 +1,482 @@
+-- The application always requests a 30-minute useful interval. For that hot
+-- path, consume response-ready room segments built during cache refresh. Keep
+-- the multirange implementation below as the generic path for other thresholds
+-- and for cache dates that predate segment generation.
+CREATE OR REPLACE FUNCTION public.get_cached_spots(
+    check_time_param TIME,
+    check_date_param DATE,
+    min_minutes_param INTEGER DEFAULT 30
+)
+RETURNS JSONB AS $$
+DECLARE
+    result JSONB;
+    check_timestamp TIMESTAMP := check_date_param + check_time_param;
+    min_interval INTERVAL := make_interval(mins => min_minutes_param);
+BEGIN
+    -- The cache stores a complete daily schedule, not a response for a
+    -- particular minute. Uncached dates use the set-based source query.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM room_availability_cache
+        WHERE check_date = check_date_param
+        LIMIT 1
+    ) THEN
+        result := COALESCE(
+            get_spots(check_time_param, check_date_param, min_minutes_param),
+            '{}'::jsonb
+        );
+        RETURN result || jsonb_build_object(
+            '_cache', jsonb_build_object(
+                'hit', false,
+                'source', 'get_spots',
+                'reason', 'date_not_cached'
+            )
+        );
+    END IF;
+
+    IF min_minutes_param = 30 AND EXISTS (
+        SELECT 1
+        FROM room_availability_cache_segments
+        WHERE check_date = check_date_param
+        LIMIT 1
+    ) THEN
+        WITH day_hours AS MATERIALIZED (
+            SELECT
+                b.name,
+                b.latitude,
+                b.longitude,
+                CASE EXTRACT(DOW FROM check_date_param)
+                    WHEN 1 THEN b.monday_open WHEN 2 THEN b.tuesday_open
+                    WHEN 3 THEN b.wednesday_open WHEN 4 THEN b.thursday_open
+                    WHEN 5 THEN b.friday_open WHEN 6 THEN b.saturday_open
+                    WHEN 0 THEN b.sunday_open
+                END AS open_time,
+                CASE EXTRACT(DOW FROM check_date_param)
+                    WHEN 1 THEN b.monday_close WHEN 2 THEN b.tuesday_close
+                    WHEN 3 THEN b.wednesday_close WHEN 4 THEN b.thursday_close
+                    WHEN 5 THEN b.friday_close WHEN 6 THEN b.saturday_close
+                    WHEN 0 THEN b.sunday_close
+                END AS close_time
+            FROM buildings b
+        ),
+        building_info AS MATERIALIZED (
+            SELECT
+                dh.*,
+                COALESCE(
+                    CASE
+                        WHEN open_time <= close_time THEN
+                            check_time_param >= open_time
+                            AND check_time_param < close_time
+                        ELSE
+                            check_time_param >= open_time
+                            OR check_time_param < close_time
+                    END,
+                    false
+                ) AS is_open
+            FROM day_hours dh
+        ),
+        room_status AS MATERIALIZED (
+            SELECT
+                s.building_name,
+                s.room_number,
+                bi.close_time,
+                s.is_occupied,
+                s.current_activity,
+                s.next_activity,
+                s.next_start_time,
+                s.meaningful_available_at,
+                s.next_island_start
+            FROM room_availability_cache_segments s
+            JOIN building_info bi ON bi.name = s.building_name
+            WHERE s.check_date = check_date_param
+              AND bi.is_open
+              AND s.segment_start <= check_time_param
+              AND s.segment_end > check_time_param
+        ),
+        rooms_by_building AS (
+            SELECT
+                rs.building_name,
+                count(*) AS total_rooms,
+                count(*) FILTER (WHERE NOT rs.is_occupied) AS available_rooms,
+                jsonb_object_agg(
+                    rs.room_number,
+                    jsonb_build_object(
+                        'status', CASE
+                            WHEN rs.is_occupied THEN 'occupied'
+                            ELSE 'available'
+                        END,
+                        'available', NOT rs.is_occupied,
+                        'currentClass', CASE
+                            WHEN rs.current_activity IS NOT NULL THEN
+                                jsonb_build_object(
+                                    'type', rs.current_activity->>'status',
+                                    'course', COALESCE(
+                                        rs.current_activity->'details'->>'course',
+                                        rs.current_activity->'details'->>'identifier'
+                                    ),
+                                    'title', rs.current_activity->'details'->>'title',
+                                    'time', jsonb_build_object(
+                                        'start', rs.current_activity->>'start',
+                                        'end', rs.current_activity->>'end'
+                                    )
+                                )
+                        END,
+                        'nextClass', CASE
+                            WHEN rs.next_activity IS NOT NULL THEN
+                                jsonb_build_object(
+                                    'type', rs.next_activity->>'status',
+                                    'course', COALESCE(
+                                        rs.next_activity->'details'->>'course',
+                                        rs.next_activity->'details'->>'identifier'
+                                    ),
+                                    'title', rs.next_activity->'details'->>'title',
+                                    'time', jsonb_build_object(
+                                        'start', rs.next_activity->>'start',
+                                        'end', rs.next_activity->>'end'
+                                    )
+                                )
+                        END,
+                        'passingPeriod',
+                            NOT rs.is_occupied
+                            AND rs.next_start_time IS NOT NULL
+                            AND rs.next_start_time - check_time_param < min_interval,
+                        'availableAt', CASE WHEN rs.is_occupied THEN
+                            LEAST(
+                                COALESCE(
+                                    rs.meaningful_available_at,
+                                    rs.close_time
+                                ),
+                                rs.close_time
+                            )::text
+                        END,
+                        'availableFor', CASE
+                            WHEN rs.is_occupied
+                             AND rs.meaningful_available_at IS NOT NULL THEN
+                                EXTRACT(EPOCH FROM (
+                                    LEAST(
+                                        COALESCE(
+                                            rs.next_island_start,
+                                            rs.close_time
+                                        ),
+                                        rs.close_time
+                                    )
+                                    - LEAST(
+                                        rs.meaningful_available_at,
+                                        rs.close_time
+                                    )
+                                )) / 60
+                            WHEN NOT rs.is_occupied THEN
+                                EXTRACT(EPOCH FROM (
+                                    COALESCE(
+                                        rs.next_start_time,
+                                        rs.close_time
+                                    ) - check_time_param
+                                )) / 60
+                        END,
+                        'availableUntil', CASE WHEN NOT rs.is_occupied THEN
+                            COALESCE(
+                                rs.next_start_time,
+                                rs.close_time
+                            )::text
+                        END
+                    )
+                    ORDER BY rs.room_number
+                ) AS rooms
+            FROM room_status rs
+            GROUP BY rs.building_name
+        )
+        SELECT jsonb_build_object(
+            'timestamp', now(),
+            'buildings', jsonb_object_agg(
+                bi.name,
+                jsonb_build_object(
+                    'name', bi.name,
+                    'coordinates', jsonb_build_object(
+                        'latitude', bi.latitude,
+                        'longitude', bi.longitude
+                    ),
+                    'hours', jsonb_build_object(
+                        'open', bi.open_time,
+                        'close', bi.close_time
+                    ),
+                    'rooms', COALESCE(rb.rooms, '{}'::jsonb),
+                    'isOpen', bi.is_open,
+                    'roomCounts', jsonb_build_object(
+                        'available', COALESCE(rb.available_rooms, 0),
+                        'total', COALESCE(rb.total_rooms, 0)
+                    )
+                )
+                ORDER BY bi.name
+            )
+        ) INTO result
+        FROM building_info bi
+        LEFT JOIN rooms_by_building rb ON rb.building_name = bi.name;
+
+        RETURN result || jsonb_build_object(
+            '_cache', jsonb_build_object(
+                'hit', true,
+                'source', 'room_availability_cache'
+            )
+        );
+    END IF;
+
+    WITH day_hours AS MATERIALIZED (
+        SELECT
+            b.name,
+            b.latitude,
+            b.longitude,
+            CASE EXTRACT(DOW FROM check_date_param)
+                WHEN 1 THEN b.monday_open WHEN 2 THEN b.tuesday_open
+                WHEN 3 THEN b.wednesday_open WHEN 4 THEN b.thursday_open
+                WHEN 5 THEN b.friday_open WHEN 6 THEN b.saturday_open
+                WHEN 0 THEN b.sunday_open
+            END AS open_time,
+            CASE EXTRACT(DOW FROM check_date_param)
+                WHEN 1 THEN b.monday_close WHEN 2 THEN b.tuesday_close
+                WHEN 3 THEN b.wednesday_close WHEN 4 THEN b.thursday_close
+                WHEN 5 THEN b.friday_close WHEN 6 THEN b.saturday_close
+                WHEN 0 THEN b.sunday_close
+            END AS close_time
+        FROM buildings b
+    ),
+    building_info AS MATERIALIZED (
+        SELECT
+            dh.*,
+            COALESCE(
+                CASE
+                    WHEN open_time <= close_time THEN
+                        check_time_param >= open_time AND check_time_param < close_time
+                    ELSE
+                        check_time_param >= open_time OR check_time_param < close_time
+                END,
+                false
+            ) AS is_open
+        FROM day_hours dh
+    ),
+    cached_rooms AS MATERIALIZED (
+        SELECT
+            c.building_name,
+            c.room_number,
+            c.busy_times,
+            c.schedule_data,
+            bi.close_time
+        FROM room_availability_cache c
+        JOIN building_info bi ON bi.name = c.building_name
+        WHERE c.check_date = check_date_param
+          AND bi.is_open
+    ),
+    activities AS MATERIALIZED (
+        SELECT
+            cr.building_name,
+            cr.room_number,
+            activity.item,
+            activity.ordinality,
+            (activity.item->>'start')::time AS start_time,
+            (activity.item->>'end')::time AS end_time
+        FROM cached_rooms cr
+        CROSS JOIN LATERAL jsonb_array_elements(
+            COALESCE(cr.schedule_data, '[]'::jsonb)
+        ) WITH ORDINALITY AS activity(item, ordinality)
+        WHERE activity.item->>'status' IN ('class', 'event')
+    ),
+    -- PostgreSQL arrays compare lexicographically. Ranking the activity keys
+    -- preserves the existing current/next tie-breakers without sorting JSON
+    -- aggregates for every room.
+    activity_choice_ordinals AS MATERIALIZED (
+        SELECT
+            building_name,
+            room_number,
+            -(
+                max(ARRAY[
+                    EXTRACT(EPOCH FROM start_time)::bigint,
+                    EXTRACT(EPOCH FROM end_time)::bigint,
+                    -ordinality
+                ]) FILTER (
+                    WHERE start_time <= check_time_param
+                      AND end_time > check_time_param
+                )
+            )[3] AS current_ordinality,
+            (
+                min(ARRAY[
+                    EXTRACT(EPOCH FROM start_time)::bigint,
+                    -EXTRACT(EPOCH FROM end_time)::bigint,
+                    ordinality
+                ]) FILTER (WHERE start_time > check_time_param)
+            )[3] AS next_ordinality
+        FROM activities
+        GROUP BY building_name, room_number
+    ),
+    activity_choices AS MATERIALIZED (
+        SELECT
+            aco.building_name,
+            aco.room_number,
+            current_activity.item AS current_activity,
+            next_activity.item AS next_activity
+        FROM activity_choice_ordinals aco
+        LEFT JOIN activities current_activity
+            ON current_activity.building_name = aco.building_name
+           AND current_activity.room_number = aco.room_number
+           AND current_activity.ordinality = aco.current_ordinality
+        LEFT JOIN activities next_activity
+            ON next_activity.building_name = aco.building_name
+           AND next_activity.room_number = aco.room_number
+           AND next_activity.ordinality = aco.next_ordinality
+    ),
+    busy_ranges AS MATERIALIZED (
+        SELECT
+            cr.building_name,
+            cr.room_number,
+            upper(br.time_range)::time AS range_end,
+            lead(lower(br.time_range)::time) OVER (
+                PARTITION BY cr.building_name, cr.room_number
+                ORDER BY br.ordinality
+            ) AS next_range_start
+        FROM cached_rooms cr
+        CROSS JOIN LATERAL unnest(
+            COALESCE(cr.busy_times, '{}'::tsmultirange)
+        ) WITH ORDINALITY AS br(time_range, ordinality)
+    ),
+    meaningful_gaps AS MATERIALIZED (
+        SELECT DISTINCT ON (building_name, room_number)
+            building_name,
+            room_number,
+            range_end AS available_at,
+            next_range_start AS next_island_start
+        FROM busy_ranges
+        WHERE range_end > check_time_param
+          AND (
+              next_range_start IS NULL
+              OR next_range_start - range_end >= min_interval
+          )
+        ORDER BY building_name, room_number, range_end
+    ),
+    room_status AS MATERIALIZED (
+        SELECT
+            cr.building_name,
+            cr.room_number,
+            cr.close_time,
+            cr.busy_times @> check_timestamp AS is_occupied,
+            ac.current_activity,
+            ac.next_activity,
+            (ac.next_activity->>'start')::time AS next_start_time,
+            mg.available_at AS meaningful_available_at,
+            mg.next_island_start
+        FROM cached_rooms cr
+        LEFT JOIN activity_choices ac
+            ON ac.building_name = cr.building_name
+           AND ac.room_number = cr.room_number
+        LEFT JOIN meaningful_gaps mg
+            ON mg.building_name = cr.building_name
+           AND mg.room_number = cr.room_number
+    ),
+    rooms_by_building AS (
+        SELECT
+            rs.building_name,
+            count(*) AS total_rooms,
+            count(*) FILTER (WHERE NOT rs.is_occupied) AS available_rooms,
+            jsonb_object_agg(
+                rs.room_number,
+                jsonb_build_object(
+                    'status', CASE WHEN rs.is_occupied THEN 'occupied' ELSE 'available' END,
+                    'available', NOT rs.is_occupied,
+                    'currentClass', CASE WHEN rs.current_activity IS NOT NULL THEN
+                        jsonb_build_object(
+                            'type', rs.current_activity->>'status',
+                            'course', COALESCE(
+                                rs.current_activity->'details'->>'course',
+                                rs.current_activity->'details'->>'identifier'
+                            ),
+                            'title', rs.current_activity->'details'->>'title',
+                            'time', jsonb_build_object(
+                                'start', rs.current_activity->>'start',
+                                'end', rs.current_activity->>'end'
+                            )
+                        )
+                    END,
+                    'nextClass', CASE WHEN rs.next_activity IS NOT NULL THEN
+                        jsonb_build_object(
+                            'type', rs.next_activity->>'status',
+                            'course', COALESCE(
+                                rs.next_activity->'details'->>'course',
+                                rs.next_activity->'details'->>'identifier'
+                            ),
+                            'title', rs.next_activity->'details'->>'title',
+                            'time', jsonb_build_object(
+                                'start', rs.next_activity->>'start',
+                                'end', rs.next_activity->>'end'
+                            )
+                        )
+                    END,
+                    'passingPeriod',
+                        NOT rs.is_occupied
+                        AND rs.next_start_time IS NOT NULL
+                        AND rs.next_start_time - check_time_param < min_interval,
+                    'availableAt', CASE WHEN rs.is_occupied THEN
+                        LEAST(
+                            COALESCE(rs.meaningful_available_at, rs.close_time),
+                            rs.close_time
+                        )::text
+                    END,
+                    'availableFor', CASE
+                        WHEN rs.is_occupied AND rs.meaningful_available_at IS NOT NULL THEN
+                            EXTRACT(EPOCH FROM (
+                                LEAST(COALESCE(rs.next_island_start, rs.close_time), rs.close_time)
+                                - LEAST(rs.meaningful_available_at, rs.close_time)
+                            )) / 60
+                        WHEN NOT rs.is_occupied THEN
+                            EXTRACT(EPOCH FROM (
+                                COALESCE(rs.next_start_time, rs.close_time) - check_time_param
+                            )) / 60
+                    END,
+                    'availableUntil', CASE WHEN NOT rs.is_occupied THEN
+                        COALESCE(rs.next_start_time, rs.close_time)::text
+                    END
+                )
+                ORDER BY rs.room_number
+            ) AS rooms
+        FROM room_status rs
+        GROUP BY rs.building_name
+    )
+    SELECT jsonb_build_object(
+        'timestamp', now(),
+        'buildings', jsonb_object_agg(
+            bi.name,
+            jsonb_build_object(
+                'name', bi.name,
+                'coordinates', jsonb_build_object(
+                    'latitude', bi.latitude,
+                    'longitude', bi.longitude
+                ),
+                'hours', jsonb_build_object(
+                    'open', bi.open_time,
+                    'close', bi.close_time
+                ),
+                'rooms', COALESCE(rb.rooms, '{}'::jsonb),
+                'isOpen', bi.is_open,
+                'roomCounts', jsonb_build_object(
+                    'available', COALESCE(rb.available_rooms, 0),
+                    'total', COALESCE(rb.total_rooms, 0)
+                )
+            )
+            ORDER BY bi.name
+        )
+    ) INTO result
+    FROM building_info bi
+    LEFT JOIN rooms_by_building rb ON rb.building_name = bi.name;
+
+    RETURN result || jsonb_build_object(
+        '_cache', jsonb_build_object(
+            'hit', true,
+            'source', 'room_availability_cache'
+        )
+    );
+END;
+$$ LANGUAGE plpgsql
+SET search_path = pg_catalog, public;
+
+REVOKE EXECUTE ON FUNCTION
+    public.get_cached_spots(time without time zone, date, integer)
+FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION
+    public.get_cached_spots(time without time zone, date, integer)
+TO anon, authenticated;


### PR DESCRIPTION
## Summary
- add a relational segment cache containing intervals where each room's occupancy and current/next activity metadata are stable
- rebuild segments automatically after each daily room-cache refresh and backfill currently cached dates
- use point lookups against those segments for the application's 30-minute hot path
- retain the existing multirange implementation for other thresholds or dates without generated segments
- preserve the existing response and cache-metadata contract

## Performance
Benchmarked in rolled-back production transactions with 10 warmed executions at each time.

Dense in-term cache (2026-09-03, about 2,600 classes and 676 rooms):

| Time | Multirange cache | Segment cache | Reduction |
| --- | ---: | ---: | ---: |
| 09:00 | 102.3 ms | 22.8 ms | 77.7% |
| 12:00 | 104.3 ms | 25.2 ms | 75.9% |
| 15:00 | 100.2 ms | 22.9 ms | 77.1% |

Current sparse cache:

| Time | Multirange cache | Segment cache | Reduction |
| --- | ---: | ---: | ---: |
| 09:00 | 19.2 ms | 14.8 ms | 22.9% |
| 12:00 | 18.7 ms | 14.6 ms | 22.2% |
| 15:00 | 18.6 ms | 14.4 ms | 22.6% |

The tradeoff is moving work to the once-daily cache refresh. On the dense date, refresh averaged 166 ms before and 2.28 s including segment generation. `service_role` has no statement timeout.

A dense date produced 5,224 segments. The tested cache (one dense date plus current sparse dates) used about 6 MB for 26,095 rows including its primary-key index.

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`
- created both migrations and exercised them in rolled-back production transactions
- zero payload mismatches across 293 lookups: dense data every five minutes plus seven cached dates hourly
- zero payload mismatches across 207 exact activity boundaries and one second before/after each boundary
- verified generic 15/60-minute thresholds continue through the existing multirange path
- verified the fast path under the `anon` role and its RLS policy
- verified multi-day cached events retain the existing timestamp-multirange occupancy behavior

The migrations have not been applied to production.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a normalized relational segment cache and routes 30-minute availability requests through point lookups while retaining the existing multirange fallback.
- Creates, secures, backfills, and automatically refreshes stable room-availability segments.
- Preserves current activity, next activity, occupancy, and meaningful-availability metadata in each segment.
- Updates `get_cached_spots` to use segments when available for the 30-minute path and otherwise use the generic cached implementation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The segment lifecycle matches the repository’s current delete-and-insert cache refresh flow, and the optimized lookup retains the established generic fallback for dates or thresholds without applicable segments.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| supabase/migrations/20260819000600_cache_normalized_room_segments.sql | Adds the segment table, access policy, deterministic segment-generation function, refresh trigger, and migration-time backfill. |
| supabase/migrations/20260819000700_use_normalized_room_segments.sql | Adds the 30-minute segment lookup path while preserving uncached-date and generic-threshold fallbacks and the existing response metadata contract. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Daily room cache refresh] --> B[Delete existing date cache]
    B --> C[Insert refreshed room cache rows]
    C --> D[After-insert statement trigger]
    D --> E[Generate stable room segments]
    F[get_cached_spots request] --> G{Date cached?}
    G -- No --> H[get_spots source query]
    G -- Yes --> I{30-minute request and segments exist?}
    I -- Yes --> J[Point lookup in segment cache]
    I -- No --> K[Existing multirange cache path]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Precompute normalized room availability ..."](https://github.com/plon/illinispots/commit/002be27b7ddfcbdb5d77890ac16b35c1237f2535) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54958585)</sub>

<!-- /greptile_comment -->