### PR TITLE
Decouple page readiness from map loading

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,6 @@ const fetchFacilityData = async (
 
 const IlliniSpotsPage: React.FC = () => {
   const { selectedDateTime } = useDateTimeContext();
-  const [mapLoaded, setMapLoaded] = useState(false);
   const [showMap, setShowMap] = useState(true);
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
 
@@ -126,14 +125,9 @@ const IlliniSpotsPage: React.FC = () => {
     [],
   );
 
-  const handleMapLoaded = useCallback(() => {
-    setMapLoaded(true);
-  }, []);
-
   const isDataReady =
     !isAcademicLoading && isAcademicSuccess && !!facilityData && !error;
-  const isMapReady = !showMap || mapLoaded;
-  const isUIReady = isDataReady && isMapReady;
+  const isUIReady = isDataReady;
   const loadingScreenError = error && !isAcademicLoading ? error : null;
 
   // Effect to trigger the loading screen fade-out when the UI is ready
@@ -173,7 +167,6 @@ const IlliniSpotsPage: React.FC = () => {
             <FacilityMap
               facilityData={isDataReady ? facilityData : null}
               onMarkerClick={handleMarkerClick}
-              onMapLoaded={handleMapLoaded}
             />
           </div>
         )}

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -8,7 +8,6 @@ import { formatTime } from "@/utils/format";
 export default function FacilityMap({
   facilityData,
   onMarkerClick,
-  onMapLoaded,
 }: MapProps) {
   const handleMarkerClick = useCallback(
     (id: string, type: FacilityType) => onMarkerClick(id, type),
@@ -22,59 +21,80 @@ export default function FacilityMap({
   >(new Map());
   const activePopupRef = useRef<mapboxgl.Popup | null>(null);
   const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const [mapError, setMapError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!mapContainer.current) return;
 
-    const styleUrl = process.env.NEXT_PUBLIC_MAPBOX_STYLE_URL;
+    setIsMapLoaded(false);
+    setMapError(null);
 
+    const styleUrl = process.env.NEXT_PUBLIC_MAPBOX_STYLE_URL;
     const token = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+
     if (!styleUrl || !token) {
-      console.error(
-        "Mapbox style and access token are not configured.",
-      );
+      console.error("Mapbox style and access token are not configured.");
+      setMapError("The map is not configured.");
       return;
     }
-    if (token) {
-      mapboxgl.accessToken = token;
-    }
 
-    map.current = new mapboxgl.Map({
-      container: mapContainer.current,
-      style: styleUrl,
-      // minZoom: 15.2,
-      antialias: true,
-    });
+    mapboxgl.accessToken = token;
 
-    map.current.on("load", () => {
-      setIsMapLoaded(true);
-      onMapLoaded?.();
+    try {
+      const mapInstance = new mapboxgl.Map({
+        container: mapContainer.current,
+        style: styleUrl,
+        // minZoom: 15.2,
+        antialias: true,
+      });
+      let hasLoaded = false;
 
-      // Hide/show POI labels depending on zoom level using Mapbox Standard basemap config
-      const m = map.current!;
-      const POI_MIN_VISIBLE_ZOOM = 17; // Hide POI labels below this zoom
+      map.current = mapInstance;
 
-      const applyPoiVisibility = () => {
-        const show = m.getZoom() >= POI_MIN_VISIBLE_ZOOM;
-        try {
-          m.setConfigProperty("basemap", "showPointOfInterestLabels", show);
-        } catch {
-          // Non-standard style or config not supported
+      mapInstance.on("error", (event) => {
+        console.error("Mapbox failed to load:", event.error);
+        if (!hasLoaded) {
+          setMapError("The map could not be loaded.");
         }
-      };
+      });
 
-      // Initialize and bind to zoom updates
-      applyPoiVisibility();
-      m.on("zoom", applyPoiVisibility);
-    });
+      mapInstance.on("load", () => {
+        hasLoaded = true;
+        setMapError(null);
+        setIsMapLoaded(true);
 
-    map.current.addControl(new mapboxgl.NavigationControl());
-    map.current.addControl(
-      new mapboxgl.GeolocateControl({
-        positionOptions: { enableHighAccuracy: true },
-        trackUserLocation: true,
-      }),
-    );
+        // Hide/show POI labels depending on zoom level using Mapbox Standard basemap config
+        const POI_MIN_VISIBLE_ZOOM = 17; // Hide POI labels below this zoom
+
+        const applyPoiVisibility = () => {
+          const show = mapInstance.getZoom() >= POI_MIN_VISIBLE_ZOOM;
+          try {
+            mapInstance.setConfigProperty(
+              "basemap",
+              "showPointOfInterestLabels",
+              show,
+            );
+          } catch {
+            // Non-standard style or config not supported
+          }
+        };
+
+        // Initialize and bind to zoom updates
+        applyPoiVisibility();
+        mapInstance.on("zoom", applyPoiVisibility);
+      });
+
+      mapInstance.addControl(new mapboxgl.NavigationControl());
+      mapInstance.addControl(
+        new mapboxgl.GeolocateControl({
+          positionOptions: { enableHighAccuracy: true },
+          trackUserLocation: true,
+        }),
+      );
+    } catch (error) {
+      console.error("Mapbox initialization failed:", error);
+      setMapError("The map could not be loaded.");
+    }
 
     return () => {
       if (map.current) {
@@ -82,7 +102,7 @@ export default function FacilityMap({
         map.current = null;
       }
     };
-  }, [onMapLoaded]);
+  }, []);
 
   useEffect(() => {
     if (!map.current || !isMapLoaded || !facilityData) return;
@@ -412,5 +432,34 @@ export default function FacilityMap({
     };
   }, [facilityData, handleMarkerClick, isMapLoaded]);
 
-  return <div ref={mapContainer} className="w-full h-full" />;
+  return (
+    <div className="relative h-full w-full bg-background">
+      <div ref={mapContainer} className="h-full w-full" />
+
+      {!isMapLoaded && !mapError && (
+        <div
+          className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-background"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="h-2 w-48 overflow-hidden rounded-full bg-gray-200">
+            <div className="loading-bar h-full" />
+          </div>
+          <span className="text-sm text-muted-foreground">Loading map…</span>
+        </div>
+      )}
+
+      {mapError && (
+        <div
+          className="absolute inset-0 z-10 flex items-center justify-center bg-background p-6 text-center"
+          role="alert"
+        >
+          <div>
+            <p className="font-medium">Map unavailable</p>
+            <p className="mt-1 text-sm text-muted-foreground">{mapError}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -177,7 +177,6 @@ export interface LibraryCoordinates {
 export interface MapProps {
   facilityData: FacilityStatus | null;
   onMarkerClick: (id: string, facilityType: FacilityType) => void;
-  onMapLoaded?: () => void;
 }
 
 export interface MarkerData {


### PR DESCRIPTION
## Summary
- reveal the application as soon as academic facility data is ready instead of waiting for Mapbox
- give the map its own loading overlay while its style and resources load
- show a local map error state for missing configuration or initialization/load failures
- keep the sidebar usable when Mapbox is slow or unavailable

## Behavior
The academic request and map initialization still run in parallel. If data finishes first, users can immediately use the sidebar while the map continues loading. Library data remains non-blocking as before.

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes academic facility data the sole gate for revealing the application, allowing the sidebar to become usable independently of Mapbox. It also moves map loading and configuration/load error feedback into the map component.
- Removes map readiness from the page-level loading-screen lifecycle.
- Adds map-local loading and unavailable overlays.
- Removes the obsolete `onMapLoaded` callback from the map component contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The sidebar now becomes available once academic data is ready, while map initialization continues independently and reports its loading or failure state within the map area.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/page.tsx | Decouples application visibility from Mapbox readiness while preserving academic-data readiness and loading-screen transitions. |
| src/components/map.tsx | Internalizes map loading state and presents local errors for missing configuration and initialization or pre-load failures. |
| src/types/index.ts | Removes the obsolete optional map-loaded callback from the FacilityMap prop contract. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Page mounts] --> B[Academic data request]
  A --> C[Mapbox initialization]
  B -->|Data ready| D[Fade out page loading screen]
  D --> E[Sidebar usable]
  C -->|Map load succeeds| F[Hide map loading overlay]
  C -->|Configuration or load failure| G[Show local map unavailable state]
  E --> F
  E --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Decouple page readiness from map loading"](https://github.com/plon/illinispots/commit/b2da873bc8c8a743fab00fd5a2a366cc0c0cc134) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54961820)</sub>

<!-- /greptile_comment -->