### PR TITLE
Add Sentry loading milestone metrics

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
 import { getUpdatedAccordionItems } from "@/utils/accordion";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import moment from "moment-timezone";
@@ -9,6 +15,10 @@ import FacilityMap from "@/components/map";
 import LoadingScreen from "@/components/LoadingScreen" // Ensure path is correct
 import { FacilityStatus, FacilityType } from "@/types";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
+import {
+  recordInitialLoadMilestone,
+  type InitialLoadMilestone,
+} from "@/utils/loadingMetrics";
 
 const fetchFacilityData = async (
   selectedDateTime: Date,
@@ -39,6 +49,17 @@ const IlliniSpotsPage: React.FC = () => {
 
   const [showLoadingScreen, setShowLoadingScreen] = useState(true);
   const [mountLoadingScreen, setMountLoadingScreen] = useState(true);
+  const recordedLoadMilestones = useRef(new Set<InitialLoadMilestone>());
+
+  const recordLoadMilestone = useCallback(
+    (milestone: InitialLoadMilestone) => {
+      if (recordedLoadMilestones.current.has(milestone)) return;
+
+      recordedLoadMilestones.current.add(milestone);
+      recordInitialLoadMilestone(milestone);
+    },
+    [],
+  );
 
   const {
     data: academicData,
@@ -60,6 +81,7 @@ const IlliniSpotsPage: React.FC = () => {
   const {
     data: libraryData,
     isFetching: isLibraryFetching,
+    isSuccess: isLibrarySuccess,
   } = useQuery<FacilityStatus, Error>({
     queryKey: ["facilities", "library", selectedDateTime.toISOString()],
     queryFn: () => fetchFacilityData(selectedDateTime, "library"),
@@ -91,6 +113,18 @@ const IlliniSpotsPage: React.FC = () => {
   }, [academicData, libraryData]);
 
   const error = academicQueryError ? academicQueryError.message : null;
+
+  useEffect(() => {
+    if (isAcademicSuccess && academicData) {
+      recordLoadMilestone("academic_data_ready");
+    }
+  }, [academicData, isAcademicSuccess, recordLoadMilestone]);
+
+  useEffect(() => {
+    if (isLibrarySuccess && libraryData) {
+      recordLoadMilestone("library_data_ready");
+    }
+  }, [isLibrarySuccess, libraryData, recordLoadMilestone]);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -133,14 +167,16 @@ const IlliniSpotsPage: React.FC = () => {
   // Effect to trigger the loading screen fade-out when the UI is ready
   useEffect(() => {
     if (isUIReady) {
+      recordLoadMilestone("content_ready");
       setShowLoadingScreen(false);
     }
-  }, [isUIReady]);
+  }, [isUIReady, recordLoadMilestone]);
 
   // Callback function passed to LoadingScreen, called when its fade-out transition ends
   const handleLoadingScreenExited = useCallback(() => {
+    recordLoadMilestone("loading_screen_exited");
     setMountLoadingScreen(false);
-  }, []);
+  }, [recordLoadMilestone]);
 
   const showFetchingOverlay =
     isAcademicFetching && !isAcademicLoading;
@@ -167,6 +203,7 @@ const IlliniSpotsPage: React.FC = () => {
             <FacilityMap
               facilityData={isDataReady ? facilityData : null}
               onMarkerClick={handleMarkerClick}
+              trackInitialLoad={mountLoadingScreen}
             />
           </div>
         )}

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -4,10 +4,16 @@ import { useRef, useEffect, useState, useCallback } from "react";
 import mapboxgl from "mapbox-gl";
 import { MarkerData, MapProps, FacilityType } from "@/types";
 import { formatTime } from "@/utils/format";
+import {
+  recordInitialLoadMilestone,
+  recordMapLoadDuration,
+  type MapLoadResult,
+} from "@/utils/loadingMetrics";
 
 export default function FacilityMap({
   facilityData,
   onMarkerClick,
+  trackInitialLoad,
 }: MapProps) {
   const handleMarkerClick = useCallback(
     (id: string, type: FacilityType) => onMarkerClick(id, type),
@@ -20,11 +26,26 @@ export default function FacilityMap({
     Map<string, { marker: mapboxgl.Marker; data: MarkerData }>
   >(new Map());
   const activePopupRef = useRef<mapboxgl.Popup | null>(null);
+  const trackInitialLoadRef = useRef(trackInitialLoad);
+  const mapLoadOutcomeRecorded = useRef(false);
+  const mapReadyRecorded = useRef(false);
   const [isMapLoaded, setIsMapLoaded] = useState(false);
   const [mapError, setMapError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!mapContainer.current) return;
+
+    const mapLoadStartedAt = performance.now();
+    const recordMapOutcome = (result: MapLoadResult) => {
+      if (mapLoadOutcomeRecorded.current) return;
+
+      mapLoadOutcomeRecorded.current = true;
+      recordMapLoadDuration(
+        performance.now() - mapLoadStartedAt,
+        result,
+        trackInitialLoadRef.current,
+      );
+    };
 
     setIsMapLoaded(false);
     setMapError(null);
@@ -34,6 +55,7 @@ export default function FacilityMap({
 
     if (!styleUrl || !token) {
       console.error("Mapbox style and access token are not configured.");
+      recordMapOutcome("missing_configuration");
       setMapError("The map is not configured.");
       return;
     }
@@ -54,12 +76,18 @@ export default function FacilityMap({
       mapInstance.on("error", (event) => {
         console.error("Mapbox failed to load:", event.error);
         if (!hasLoaded) {
+          recordMapOutcome("load_error");
           setMapError("The map could not be loaded.");
         }
       });
 
       mapInstance.on("load", () => {
         hasLoaded = true;
+        recordMapOutcome("success");
+        if (trackInitialLoadRef.current && !mapReadyRecorded.current) {
+          mapReadyRecorded.current = true;
+          recordInitialLoadMilestone("map_ready");
+        }
         setMapError(null);
         setIsMapLoaded(true);
 
@@ -93,6 +121,7 @@ export default function FacilityMap({
       );
     } catch (error) {
       console.error("Mapbox initialization failed:", error);
+      recordMapOutcome("initialization_error");
       setMapError("The map could not be loaded.");
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -177,6 +177,7 @@ export interface LibraryCoordinates {
 export interface MapProps {
   facilityData: FacilityStatus | null;
   onMarkerClick: (id: string, facilityType: FacilityType) => void;
+  trackInitialLoad: boolean;
 }
 
 export interface MarkerData {

--- a/src/utils/loadingMetrics.ts
+++ b/src/utils/loadingMetrics.ts
@@ -1,0 +1,60 @@
+import * as Sentry from "@sentry/nextjs";
+
+export type InitialLoadMilestone =
+  | "academic_data_ready"
+  | "library_data_ready"
+  | "content_ready"
+  | "loading_screen_exited"
+  | "map_ready";
+
+export type MapLoadResult =
+  | "success"
+  | "missing_configuration"
+  | "initialization_error"
+  | "load_error";
+
+export function recordInitialLoadMilestone(
+  milestone: InitialLoadMilestone,
+): void {
+  if (typeof performance === "undefined") return;
+
+  try {
+    Sentry.metrics.distribution(
+      "ui.initial_load.duration",
+      performance.now(),
+      {
+        unit: "millisecond",
+        attributes: { milestone },
+      },
+    );
+  } catch (error) {
+    console.warn("Failed to record initial-load metric:", error);
+  }
+}
+
+export function recordMapLoadDuration(
+  duration: number,
+  result: MapLoadResult,
+  initialLoad: boolean,
+): void {
+  try {
+    Sentry.metrics.distribution("ui.map.load.duration", duration, {
+      unit: "millisecond",
+      attributes: {
+        result,
+        initial_load: initialLoad,
+      },
+    });
+
+    if (result !== "success") {
+      Sentry.metrics.count("ui.map.load.failure", 1, {
+        attributes: {
+          reason: result,
+          initial_load: initialLoad,
+        },
+      });
+    }
+  } catch (error) {
+    console.warn("Failed to record map-load metric:", error);
+  }
+}


### PR DESCRIPTION
## Summary
- record navigation-relative Sentry distribution metrics for academic data, library data, content readiness, loading-screen exit, and initial map readiness
- record Mapbox-specific load duration with success/failure and initial-load attributes
- count missing configuration, initialization failures, and pre-load Mapbox errors
- deduplicate initial milestones within a page mount so query updates do not pollute startup measurements

## Sentry metrics
- `ui.initial_load.duration` (`milestone` attribute)
- `ui.map.load.duration` (`result` and `initial_load` attributes)
- `ui.map.load.failure` (`reason` and `initial_load` attributes)

These allow p50/p95 comparisons of map readiness against academic and library data readiness, while preserving the existing automatic browser traces and server spans.

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds navigation-relative Sentry milestones for initial data, content, loading-screen, and map readiness, plus categorized Mapbox load durations and failure counters.
- Deduplicates initial milestones for each page mount.
- Tracks Mapbox success, configuration, initialization, and pre-load error outcomes.
- Associates map metrics with whether the map was mounted during initial loading.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The added telemetry is guarded against duplicate initial milestones and metric-reporting exceptions, while current component lifecycles reset map outcome state on every reachable remount.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/page.tsx | Adds per-mount milestone deduplication and records data, content, loading-screen, and initial-map lifecycle state. |
| src/components/map.tsx | Measures each map mount from initialization through its first success or categorized failure and records initial map readiness. |
| src/utils/loadingMetrics.ts | Introduces guarded Sentry helpers for initial-load distributions and Mapbox duration and failure metrics. |
| src/types/index.ts | Extends the map component contract with the required initial-load classification flag. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Page as IlliniSpotsPage
    participant Query as React Query
    participant Screen as LoadingScreen
    participant Map as FacilityMap
    participant Sentry
    Query-->>Page: Academic/library data ready
    Page->>Sentry: ui.initial_load.duration milestones
    Page->>Screen: Begin fade-out
    Screen-->>Page: onExited
    Page->>Sentry: loading_screen_exited milestone
    Map-->>Map: load or pre-load failure
    Map->>Sentry: ui.map.load.duration
    alt Successful initial map load
        Map->>Sentry: map_ready milestone
    else Failed map load
        Map->>Sentry: ui.map.load.failure
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Sentry loading milestone metrics"](https://github.com/plon/illinispots/commit/567abf3136604d752e362891300646aa4f7c3bfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54965362)</sub>

<!-- /greptile_comment -->