### PR TITLE
Avoid loading Mapbox when the map is disabled

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,11 +68,6 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-title" content="illiniSpots" />
         <link rel="canonical" href="https://illinispots.com/" />
         <link rel="manifest" href="/manifest.json" />
-        <link
-          rel="stylesheet"
-          href="https://api.mapbox.com/mapbox-gl-js/v3.5.1/mapbox-gl.css"
-          crossOrigin="anonymous"
-        />
       </head>
       <body className={inter.className}>
         <Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,15 +10,31 @@ import React, {
 import { getUpdatedAccordionItems } from "@/utils/accordion";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import moment from "moment-timezone";
+import dynamic from "next/dynamic";
 import LeftSidebar from "@/components/left";
-import FacilityMap from "@/components/map";
-import LoadingScreen from "@/components/LoadingScreen" // Ensure path is correct
+import LoadingScreen from "@/components/LoadingScreen";
 import { FacilityStatus, FacilityType } from "@/types";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
 import {
   recordInitialLoadMilestone,
   type InitialLoadMilestone,
 } from "@/utils/loadingMetrics";
+
+const FacilityMap = dynamic(() => import("@/components/map"), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex h-full w-full flex-col items-center justify-center gap-3 bg-background"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="h-2 w-48 overflow-hidden rounded-full bg-gray-200">
+        <div className="loading-bar h-full" />
+      </div>
+      <span className="text-sm text-muted-foreground">Loading map…</span>
+    </div>
+  ),
+});
 
 const fetchFacilityData = async (
   selectedDateTime: Date,
@@ -44,7 +60,9 @@ const fetchFacilityData = async (
 
 const IlliniSpotsPage: React.FC = () => {
   const { selectedDateTime } = useDateTimeContext();
-  const [showMap, setShowMap] = useState(true);
+  const [showMapPreference, setShowMapPreference] = useState<boolean | null>(
+    null,
+  );
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
 
   const [showLoadingScreen, setShowLoadingScreen] = useState(true);
@@ -53,12 +71,17 @@ const IlliniSpotsPage: React.FC = () => {
 
   const recordLoadMilestone = useCallback(
     (milestone: InitialLoadMilestone) => {
-      if (recordedLoadMilestones.current.has(milestone)) return;
+      if (
+        showMapPreference === null ||
+        recordedLoadMilestones.current.has(milestone)
+      ) {
+        return;
+      }
 
       recordedLoadMilestones.current.add(milestone);
-      recordInitialLoadMilestone(milestone);
+      recordInitialLoadMilestone(milestone, showMapPreference);
     },
-    [],
+    [showMapPreference],
   );
 
   const {
@@ -127,19 +150,27 @@ const IlliniSpotsPage: React.FC = () => {
   }, [isLibrarySuccess, libraryData, recordLoadMilestone]);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      const storedShowMap = localStorage.getItem("showMap");
-      if (storedShowMap !== null) {
-        setShowMap(storedShowMap === "true");
-      }
-    }
+    const storedShowMap = localStorage.getItem("showMap");
+    setShowMapPreference(storedShowMap === null || storedShowMap === "true");
   }, []);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      localStorage.setItem("showMap", showMap.toString());
+    if (showMapPreference !== null) {
+      localStorage.setItem("showMap", showMapPreference.toString());
     }
-  }, [showMap]);
+  }, [showMapPreference]);
+
+  const setShowMap = useCallback<React.Dispatch<React.SetStateAction<boolean>>>(
+    (value) => {
+      setShowMapPreference((currentValue) => {
+        const hydratedValue = currentValue ?? true;
+        return typeof value === "function" ? value(hydratedValue) : value;
+      });
+    },
+    [],
+  );
+
+  const showMap = showMapPreference === true;
 
   const handleMarkerClick = useCallback(
     (id: string, facilityType: FacilityType) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -150,13 +150,21 @@ const IlliniSpotsPage: React.FC = () => {
   }, [isLibrarySuccess, libraryData, recordLoadMilestone]);
 
   useEffect(() => {
-    const storedShowMap = localStorage.getItem("showMap");
-    setShowMapPreference(storedShowMap === null || storedShowMap === "true");
+    try {
+      const storedShowMap = localStorage.getItem("showMap");
+      setShowMapPreference(storedShowMap === null || storedShowMap === "true");
+    } catch {
+      setShowMapPreference(true);
+    }
   }, []);
 
   useEffect(() => {
-    if (showMapPreference !== null) {
+    if (showMapPreference === null) return;
+
+    try {
       localStorage.setItem("showMap", showMapPreference.toString());
+    } catch {
+      // Continue without persistence when browser storage is unavailable.
     }
   }, [showMapPreference]);
 

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useEffect, useState, useCallback } from "react";
 import mapboxgl from "mapbox-gl";
+import "mapbox-gl/dist/mapbox-gl.css";
 import { MarkerData, MapProps, FacilityType } from "@/types";
 import { formatTime } from "@/utils/format";
 import {
@@ -86,7 +87,7 @@ export default function FacilityMap({
         recordMapOutcome("success");
         if (trackInitialLoadRef.current && !mapReadyRecorded.current) {
           mapReadyRecorded.current = true;
-          recordInitialLoadMilestone("map_ready");
+          recordInitialLoadMilestone("map_ready", true);
         }
         setMapError(null);
         setIsMapLoaded(true);

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -34,6 +34,10 @@ export default function FacilityMap({
   const [mapError, setMapError] = useState<string | null>(null);
 
   useEffect(() => {
+    trackInitialLoadRef.current = trackInitialLoad;
+  }, [trackInitialLoad]);
+
+  useEffect(() => {
     if (!mapContainer.current) return;
 
     const mapLoadStartedAt = performance.now();

--- a/src/utils/loadingMetrics.ts
+++ b/src/utils/loadingMetrics.ts
@@ -15,6 +15,7 @@ export type MapLoadResult =
 
 export function recordInitialLoadMilestone(
   milestone: InitialLoadMilestone,
+  mapEnabled: boolean,
 ): void {
   if (typeof performance === "undefined") return;
 
@@ -24,7 +25,10 @@ export function recordInitialLoadMilestone(
       performance.now(),
       {
         unit: "millisecond",
-        attributes: { milestone },
+        attributes: {
+          milestone,
+          map_enabled: mapEnabled,
+        },
       },
     );
   } catch (error) {


### PR DESCRIPTION
## Summary
- hydrate the saved map preference before rendering map-enabled UI
- lazy-load the map component and its CSS only when the map is enabled
- avoid overwriting the saved preference during initial hydration
- tag initial-load metrics with `map_enabled` for cohort comparisons

## Performance impact
For map-disabled users, the production build no longer includes the Mapbox dynamic assets in the initial page HTML. This defers:
- 1,572,018 bytes JavaScript (424,876 bytes gzip)
- 36,860 bytes CSS (4,906 bytes gzip)
- Mapbox initialization and subsequent style/tile requests

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- verified the Mapbox JS/CSS chunks are absent from generated route HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Map Loading**
  * Maps now load dynamically with a clear, accessible loading state.
  * Map styling loads reliably without affecting the rest of the page.

* **Improved Preferences**
  * Map visibility preferences are restored and saved more consistently.
  * Initial page loading now waits for the map visibility preference before completing.

* **Bug Fixes**
  * Improved map readiness tracking and loading behavior for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR defers Mapbox loading until the hydrated user preference enables the map and adds preference-aware initial-load metrics.
- Hydrates the saved map preference before rendering map-enabled UI.
- Dynamically imports the map component and colocates Mapbox CSS with that deferred bundle.
- Prevents initial preference hydration from overwriting stored state.
- Tags initial-load metrics with the map-enabled cohort.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/page.tsx | Hydrates and persists the map preference, conditionally mounts a dynamically imported map, and attaches the preference cohort to load milestones. |
| src/components/map.tsx | Moves Mapbox CSS into the deferred map module and keeps initial-load tracking synchronized with the latest prop. |
| src/app/layout.tsx | Removes the globally loaded Mapbox stylesheet so map-disabled sessions avoid fetching it. |
| src/utils/loadingMetrics.ts | Adds the map-enabled attribute to initial-load duration metrics. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page mounts] --> B[Read saved map preference]
    B -->|Enabled or absent| C[Render map container]
    B -->|Disabled| D[Render sidebar without map]
    B -->|Storage unavailable| C
    C --> E[Load FacilityMap and Mapbox CSS dynamically]
    E --> F[Initialize Mapbox]
    C --> G[Record initial-load metrics with map_enabled true]
    D --> H[Record initial-load metrics with map_enabled false]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Keep map load tracking state current"](https://github.com/plon/illinispots/commit/2a598027eb41ac8033a86081d16fa980ac73655d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54971057)</sub>

<!-- /greptile_comment -->