### PR TITLE
fix(observability): Configure Sentry by deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ SUPABASE_KEY=your_server_key
 MAPBOX_ACCESS_TOKEN=your_public_mapbox_token
 MAPBOX_STYLE_URL=mapbox://styles/your-user/your-style
 
-# Optional observability configuration
+# Optional observability configuration; omit the DSNs to disable local telemetry.
 SENTRY_DSN=
 VITE_SENTRY_DSN=
 SENTRY_ENVIRONMENT=development

--- a/src/client/env.d.ts
+++ b/src/client/env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string;
+  readonly VITE_VERCEL_ENV?: string;
+  readonly VITE_VERCEL_TARGET_ENV?: string;
 }
 
 interface ImportMeta {

--- a/src/client/observability.test.ts
+++ b/src/client/observability.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { resolveClientSentryEnvironment } from "./observability";
+
+describe("resolveClientSentryEnvironment", () => {
+  it("uses the Vercel target so custom environments retain their name", () => {
+    expect(
+      resolveClientSentryEnvironment({
+        VITE_VERCEL_TARGET_ENV: "staging",
+        VITE_VERCEL_ENV: "preview",
+        MODE: "production",
+      }),
+    ).toBe("staging");
+  });
+
+  it("falls back through the standard Vercel and Vite environments", () => {
+    expect(
+      resolveClientSentryEnvironment({
+        VITE_VERCEL_ENV: "preview",
+        MODE: "production",
+      }),
+    ).toBe("preview");
+    expect(resolveClientSentryEnvironment({ MODE: "development" })).toBe(
+      "development",
+    );
+  });
+});

--- a/src/client/observability.ts
+++ b/src/client/observability.ts
@@ -9,7 +9,10 @@ export function initializeClientObservability(router: AnyRouter): void {
 
   Sentry.init({
     dsn,
-    environment: import.meta.env.MODE,
+    environment:
+      import.meta.env.VITE_VERCEL_TARGET_ENV ||
+      import.meta.env.VITE_VERCEL_ENV ||
+      import.meta.env.MODE,
     integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
     tracesSampleRate: 1,
     sendDefaultPii: false,

--- a/src/client/observability.ts
+++ b/src/client/observability.ts
@@ -1,6 +1,22 @@
 import * as Sentry from "@sentry/react";
 import type { AnyRouter } from "@tanstack/react-router";
 
+type ClientEnvironmentVariables = {
+  readonly MODE: string;
+  readonly VITE_VERCEL_ENV?: string;
+  readonly VITE_VERCEL_TARGET_ENV?: string;
+};
+
+export function resolveClientSentryEnvironment(
+  environment: ClientEnvironmentVariables = import.meta.env,
+): string {
+  return (
+    environment.VITE_VERCEL_TARGET_ENV ||
+    environment.VITE_VERCEL_ENV ||
+    environment.MODE
+  );
+}
+
 export function initializeClientObservability(router: AnyRouter): void {
   if (Sentry.isInitialized()) return;
 
@@ -9,10 +25,7 @@ export function initializeClientObservability(router: AnyRouter): void {
 
   Sentry.init({
     dsn,
-    environment:
-      import.meta.env.VITE_VERCEL_TARGET_ENV ||
-      import.meta.env.VITE_VERCEL_ENV ||
-      import.meta.env.MODE,
+    environment: resolveClientSentryEnvironment(),
     integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
     tracesSampleRate: 1,
     sendDefaultPii: false,

--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { resolveSentryEnvironment } from "./config";
+
+describe("resolveSentryEnvironment", () => {
+  it("uses the Vercel target so custom environments retain their name", () => {
+    expect(
+      resolveSentryEnvironment({
+        VERCEL_TARGET_ENV: "staging",
+        VERCEL_ENV: "preview",
+        NODE_ENV: "production",
+      }),
+    ).toBe("staging");
+  });
+
+  it("allows an explicit Sentry environment to override the platform", () => {
+    expect(
+      resolveSentryEnvironment({
+        SENTRY_ENVIRONMENT: "testing",
+        VERCEL_TARGET_ENV: "preview",
+      }),
+    ).toBe("testing");
+  });
+
+  it("falls back through the standard Vercel and runtime environments", () => {
+    expect(resolveSentryEnvironment({ VERCEL_ENV: "preview" })).toBe(
+      "preview",
+    );
+    expect(resolveSentryEnvironment({ NODE_ENV: "test" })).toBe("test");
+    expect(resolveSentryEnvironment({})).toBe("development");
+  });
+});

--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { resolveSentryEnvironment } from "./config";
+import { getServerConfig, resolveSentryEnvironment } from "./config";
 
 describe("resolveSentryEnvironment", () => {
   it("uses the Vercel target so custom environments retain their name", () => {
@@ -27,5 +27,27 @@ describe("resolveSentryEnvironment", () => {
     );
     expect(resolveSentryEnvironment({ NODE_ENV: "test" })).toBe("test");
     expect(resolveSentryEnvironment({})).toBe("development");
+  });
+});
+
+describe("getServerConfig", () => {
+  it("enables server telemetry only when a DSN is configured", () => {
+    expect(
+      getServerConfig({
+        PORT: "4000",
+        SENTRY_DSN: "https://public@example.ingest.sentry.io/1",
+        VERCEL_TARGET_ENV: "preview",
+      }),
+    ).toEqual({
+      environment: "preview",
+      port: 4000,
+      sentryDsn: "https://public@example.ingest.sentry.io/1",
+    });
+
+    expect(getServerConfig({})).toEqual({
+      environment: "development",
+      port: 3000,
+      sentryDsn: undefined,
+    });
   });
 });

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,8 +1,5 @@
 import type { ClientConfig } from "../types";
 
-const DEFAULT_SENTRY_DSN =
-  "https://b346a7b285d735686ab9ea2fd7f51413@o4511882586292224.ingest.us.sentry.io/4511882595401729";
-
 export interface SupabaseConfig {
   url: string;
   key: string;
@@ -63,12 +60,14 @@ export function resolveSentryEnvironment(
   );
 }
 
-export function getServerConfig() {
-  const parsedPort = Number.parseInt(process.env.PORT ?? "3000", 10);
+export function getServerConfig(
+  environment: EnvironmentVariables = process.env,
+) {
+  const parsedPort = Number.parseInt(environment.PORT ?? "3000", 10);
 
   return {
-    environment: resolveSentryEnvironment(),
+    environment: resolveSentryEnvironment(environment),
     port: Number.isFinite(parsedPort) ? parsedPort : 3000,
-    sentryDsn: process.env.SENTRY_DSN ?? DEFAULT_SENTRY_DSN,
+    sentryDsn: environment.SENTRY_DSN,
   };
 }

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -8,6 +8,8 @@ export interface SupabaseConfig {
   key: string;
 }
 
+type EnvironmentVariables = Readonly<Record<string, string | undefined>>;
+
 export class ServerConfigurationError extends Error {
   constructor(message: string) {
     super(message);
@@ -49,11 +51,23 @@ export function getClientConfig(): ClientConfig {
   };
 }
 
+export function resolveSentryEnvironment(
+  environment: EnvironmentVariables = process.env,
+): string {
+  return (
+    environment.SENTRY_ENVIRONMENT ||
+    environment.VERCEL_TARGET_ENV ||
+    environment.VERCEL_ENV ||
+    environment.NODE_ENV ||
+    "development"
+  );
+}
+
 export function getServerConfig() {
   const parsedPort = Number.parseInt(process.env.PORT ?? "3000", 10);
 
   return {
-    environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV ?? "development",
+    environment: resolveSentryEnvironment(),
     port: Number.isFinite(parsedPort) ? parsedPort : 3000,
     sentryDsn: process.env.SENTRY_DSN ?? DEFAULT_SENTRY_DSN,
   };

--- a/src/server/observability.ts
+++ b/src/server/observability.ts
@@ -3,11 +3,13 @@ import { getServerConfig } from "./config";
 
 const config = getServerConfig();
 
-Sentry.init({
-  dsn: config.sentryDsn,
-  environment: config.environment,
-  tracesSampleRate: 1,
-  sendDefaultPii: false,
-});
+if (config.sentryDsn) {
+  Sentry.init({
+    dsn: config.sentryDsn,
+    environment: config.environment,
+    tracesSampleRate: 1,
+    sendDefaultPii: false,
+  });
+}
 
 export { Sentry };


### PR DESCRIPTION
Configures browser and server Sentry consistently across deployed Vercel targets. Production and Preview now receive the same project DSN through their scoped `VITE_SENTRY_DSN` and `SENTRY_DSN` variables, while events use the Vercel target as their Sentry environment so production, preview, and future custom targets such as `staging` remain filterable.

Local Development receives neither DSN and therefore initializes neither SDK, eliminating the previous hard-coded server fallback and local noise. An explicit `SENTRY_ENVIRONMENT` still overrides platform detection for non-standard deployments, and focused coverage locks down target precedence, configured enablement, and disabled local behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sentry environment detection now supports Vercel deployment environment variables with sensible fallbacks.
  - Server telemetry is enabled only when a Sentry DSN is explicitly configured.
  - Client and server environments can be identified consistently across deployment platforms.

- **Bug Fixes**
  - Removed the built-in Sentry DSN to prevent unintended telemetry.

- **Documentation**
  - Clarified that Sentry DSN settings are optional and can disable local telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns browser and server Sentry environment labels with Vercel deployment targets and disables server telemetry when no DSN is configured.
- Adds browser coverage for custom-target precedence and fallback behavior.
- Adds server coverage for environment resolution and DSN-based enablement.
- Removes the hard-coded server DSN and documents local telemetry opt-out behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/client/observability.ts | Extracts browser Sentry environment resolution with custom Vercel target precedence; the previously reported coverage gap is addressed by focused tests. |
| src/client/observability.test.ts | Directly verifies that browser environment resolution prefers `VITE_VERCEL_TARGET_ENV`, then `VITE_VERCEL_ENV`, then Vite mode. |
| src/server/config.ts | Resolves server environment labels by explicit override and deployment target while requiring an explicitly configured Sentry DSN. |
| src/server/observability.ts | Initializes server Sentry only when configuration supplies a DSN. |
| src/server/config.test.ts | Covers server target precedence, explicit overrides, runtime fallbacks, and DSN-based configuration. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(observability): Cover browser envir..."](https://github.com/plon/illinispots/commit/bcaff525fedf4720513349717b6f5c04f53462a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55425844)</sub>

<!-- /greptile_comment -->