### PR TITLE
fix(availability): Correct partial and overnight results

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "react-dom": "^19.2.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",

--- a/src/server/services/external-contracts.ts
+++ b/src/server/services/external-contracts.ts
@@ -1,372 +1,186 @@
+import { z } from "zod";
 import type {
-  ClassInfo,
   ReservationResponse,
-  ReservationSlot,
   RoomScheduleBlock,
 } from "../../types";
 
-type JsonRecord = Record<string, unknown>;
+const optionalStringSchema = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? undefined);
+
+const finiteNumberSchema = z.number().finite();
+
+const optionalNumberSchema = finiteNumberSchema
+  .nullish()
+  .transform((value) => value ?? undefined);
+
+const optionalBooleanSchema = z
+  .boolean()
+  .nullish()
+  .transform((value) => value ?? undefined);
+
+const classTimeSchema = z.object({
+  start: z.string(),
+  end: z.string(),
+});
+
+const classInfoSchema = z
+  .looseObject({
+    course: z
+      .string()
+      .nullish()
+      .transform((value) => value ?? ""),
+    title: z.string(),
+    time: classTimeSchema
+      .nullish()
+      .transform((value) => value ?? undefined),
+  })
+  .transform(({ time, ...classInfo }) =>
+    time ? { ...classInfo, time } : classInfo,
+  );
+
+const academicRoomSchema = z.object({
+  status: z.enum(["available", "occupied"]),
+  passingPeriod: optionalBooleanSchema,
+  availableAt: optionalStringSchema,
+  availableFor: optionalNumberSchema,
+  availableUntil: optionalStringSchema,
+  currentClass: classInfoSchema
+    .nullish()
+    .transform((value) => value ?? undefined),
+  nextClass: classInfoSchema
+    .nullish()
+    .transform((value) => value ?? undefined),
+});
+
+const academicBuildingSchema = z.object({
+  name: z.string(),
+  coordinates: z.object({
+    latitude: finiteNumberSchema,
+    longitude: finiteNumberSchema,
+  }),
+  hours: z.object({
+    open: z
+      .string()
+      .nullish()
+      .transform((value) => value ?? ""),
+    close: z
+      .string()
+      .nullish()
+      .transform((value) => value ?? ""),
+  }),
+  rooms: z.record(z.string(), academicRoomSchema),
+  isOpen: z.boolean(),
+  roomCounts: z.object({
+    available: finiteNumberSchema,
+    total: finiteNumberSchema,
+  }),
+});
+
+const cacheMetadataSchema = z.object({
+  hit: optionalBooleanSchema,
+  source: optionalStringSchema,
+  reason: optionalStringSchema,
+});
+
+const academicAvailabilitySchema = z.object({
+  _cache: cacheMetadataSchema
+    .nullish()
+    .transform((value) => value ?? undefined),
+  buildings: z.record(z.string(), academicBuildingSchema),
+});
+
+const reservationResponseSchema = z.object({
+  slots: z.array(
+    z.object({
+      itemId: finiteNumberSchema,
+      start: z.string(),
+      end: z.string(),
+      className: optionalStringSchema,
+    }),
+  ),
+});
+
+const blockDetailsSchema = z.object({
+  type: z.enum(["class", "event"]),
+  title: z.string(),
+  course: optionalStringSchema,
+  identifier: optionalStringSchema,
+});
+
+const roomScheduleSchema = z.array(
+  z.object({
+    start: z.string(),
+    end: z.string(),
+    status: z.enum(["available", "class", "event"]),
+    details: blockDetailsSchema
+      .nullish()
+      .transform((value) => value ?? null),
+  }),
+);
+
+export type AcademicRoomPayload = z.output<typeof academicRoomSchema>;
+export type AcademicBuildingPayload = z.output<
+  typeof academicBuildingSchema
+>;
+export type AcademicAvailabilityPayload = z.output<
+  typeof academicAvailabilitySchema
+>;
+
+function formatIssuePath(path: PropertyKey[]): string {
+  if (path.length === 0) return "root";
+
+  return path.reduce<string>((formatted, segment) => {
+    if (typeof segment === "number") {
+      return `${formatted}[${segment}]`;
+    }
+
+    const key = String(segment);
+    return formatted ? `${formatted}.${key}` : key;
+  }, "");
+}
 
 export class ExternalResponseError extends Error {
-  constructor(source: string, path: string, expectation: string) {
-    super(`Invalid ${source} response at ${path}: expected ${expectation}`);
+  constructor(source: string, error: z.ZodError) {
+    const issue = error.issues[0];
+    const detail = issue
+      ? ` at ${formatIssuePath(issue.path)}: ${issue.message}`
+      : "";
+
+    super(`Invalid ${source} response${detail}`, { cause: error });
     this.name = "ExternalResponseError";
   }
 }
 
-function readRecord(value: unknown, source: string, path: string): JsonRecord {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new ExternalResponseError(source, path, "an object");
-  }
-
-  return value as JsonRecord;
-}
-
-function readArray(value: unknown, source: string, path: string): unknown[] {
-  if (!Array.isArray(value)) {
-    throw new ExternalResponseError(source, path, "an array");
-  }
-
-  return value;
-}
-
-function readString(
+function parseExternal<T>(
+  schema: z.ZodType<T>,
   value: unknown,
   source: string,
-  path: string,
-): string {
-  if (typeof value !== "string") {
-    throw new ExternalResponseError(source, path, "a string");
+): T {
+  const result = schema.safeParse(value);
+
+  if (!result.success) {
+    throw new ExternalResponseError(source, result.error);
   }
 
-  return value;
-}
-
-function readNumber(
-  value: unknown,
-  source: string,
-  path: string,
-): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new ExternalResponseError(source, path, "a finite number");
-  }
-
-  return value;
-}
-
-function readBoolean(
-  value: unknown,
-  source: string,
-  path: string,
-): boolean {
-  if (typeof value !== "boolean") {
-    throw new ExternalResponseError(source, path, "a boolean");
-  }
-
-  return value;
-}
-
-function readOptionalString(
-  value: unknown,
-  source: string,
-  path: string,
-): string | undefined {
-  return value === null || value === undefined
-    ? undefined
-    : readString(value, source, path);
-}
-
-function readOptionalNumber(
-  value: unknown,
-  source: string,
-  path: string,
-): number | undefined {
-  return value === null || value === undefined
-    ? undefined
-    : readNumber(value, source, path);
-}
-
-function readOptionalBoolean(
-  value: unknown,
-  source: string,
-  path: string,
-): boolean | undefined {
-  return value === null || value === undefined
-    ? undefined
-    : readBoolean(value, source, path);
-}
-
-function parseClassInfo(
-  value: unknown,
-  source: string,
-  path: string,
-): ClassInfo | undefined {
-  if (value === null || value === undefined) return undefined;
-
-  const record = readRecord(value, source, path);
-  const course = readOptionalString(record.course, source, `${path}.course`);
-  const title = readString(record.title, source, `${path}.title`);
-  let time: ClassInfo["time"];
-
-  if (record.time !== null && record.time !== undefined) {
-    const timeRecord = readRecord(record.time, source, `${path}.time`);
-    time = {
-      start: readString(timeRecord.start, source, `${path}.time.start`),
-      end: readString(timeRecord.end, source, `${path}.time.end`),
-    };
-  }
-
-  return {
-    ...record,
-    course: course ?? "",
-    title,
-    ...(time ? { time } : {}),
-  };
-}
-
-export interface AcademicBuildingPayload {
-  name: string;
-  coordinates: { latitude: number; longitude: number };
-  hours: { open: string; close: string };
-  rooms: Record<string, AcademicRoomPayload>;
-  isOpen: boolean;
-  roomCounts: { available: number; total: number };
-}
-
-export interface AcademicRoomPayload {
-  status: "available" | "occupied";
-  passingPeriod?: boolean;
-  availableAt?: string;
-  availableFor?: number;
-  availableUntil?: string;
-  currentClass?: ClassInfo;
-  nextClass?: ClassInfo;
-}
-
-export interface AcademicAvailabilityPayload {
-  _cache?: {
-    hit?: boolean;
-    source?: string;
-    reason?: string;
-  };
-  buildings: Record<string, AcademicBuildingPayload>;
-}
-
-function parseAcademicRoom(
-  value: unknown,
-  path: string,
-): AcademicRoomPayload {
-  const source = "academic availability";
-  const record = readRecord(value, source, path);
-  const status = readString(record.status, source, `${path}.status`);
-  if (status !== "available" && status !== "occupied") {
-    throw new ExternalResponseError(
-      source,
-      `${path}.status`,
-      '"available" or "occupied"',
-    );
-  }
-
-  return {
-    status,
-    passingPeriod: readOptionalBoolean(
-      record.passingPeriod,
-      source,
-      `${path}.passingPeriod`,
-    ),
-    availableAt: readOptionalString(
-      record.availableAt,
-      source,
-      `${path}.availableAt`,
-    ),
-    availableFor: readOptionalNumber(
-      record.availableFor,
-      source,
-      `${path}.availableFor`,
-    ),
-    availableUntil: readOptionalString(
-      record.availableUntil,
-      source,
-      `${path}.availableUntil`,
-    ),
-    currentClass: parseClassInfo(
-      record.currentClass,
-      source,
-      `${path}.currentClass`,
-    ),
-    nextClass: parseClassInfo(
-      record.nextClass,
-      source,
-      `${path}.nextClass`,
-    ),
-  };
+  return result.data;
 }
 
 export function parseAcademicAvailabilityPayload(
   value: unknown,
 ): AcademicAvailabilityPayload {
-  const source = "academic availability";
-  const root = readRecord(value, source, "root");
-  const buildingsRecord = readRecord(root.buildings, source, "buildings");
-  const buildings: Record<string, AcademicBuildingPayload> = {};
-
-  for (const [buildingId, buildingValue] of Object.entries(buildingsRecord)) {
-    const path = `buildings.${buildingId}`;
-    const building = readRecord(buildingValue, source, path);
-    const coordinates = readRecord(
-      building.coordinates,
-      source,
-      `${path}.coordinates`,
-    );
-    const hours = readRecord(building.hours, source, `${path}.hours`);
-    const roomCounts = readRecord(
-      building.roomCounts,
-      source,
-      `${path}.roomCounts`,
-    );
-    const roomsRecord = readRecord(building.rooms, source, `${path}.rooms`);
-    const rooms: AcademicBuildingPayload["rooms"] = {};
-
-    for (const [roomNumber, roomValue] of Object.entries(roomsRecord)) {
-      rooms[roomNumber] = parseAcademicRoom(
-        roomValue,
-        `${path}.rooms.${roomNumber}`,
-      );
-    }
-
-    buildings[buildingId] = {
-      name: readString(building.name, source, `${path}.name`),
-      coordinates: {
-        latitude: readNumber(
-          coordinates.latitude,
-          source,
-          `${path}.coordinates.latitude`,
-        ),
-        longitude: readNumber(
-          coordinates.longitude,
-          source,
-          `${path}.coordinates.longitude`,
-        ),
-      },
-      hours: {
-        open:
-          readOptionalString(hours.open, source, `${path}.hours.open`) ?? "",
-        close:
-          readOptionalString(hours.close, source, `${path}.hours.close`) ?? "",
-      },
-      rooms,
-      isOpen: readBoolean(building.isOpen, source, `${path}.isOpen`),
-      roomCounts: {
-        available: readNumber(
-          roomCounts.available,
-          source,
-          `${path}.roomCounts.available`,
-        ),
-        total: readNumber(
-          roomCounts.total,
-          source,
-          `${path}.roomCounts.total`,
-        ),
-      },
-    };
-  }
-
-  let cache: AcademicAvailabilityPayload["_cache"];
-  if (root._cache !== null && root._cache !== undefined) {
-    const cacheRecord = readRecord(root._cache, source, "_cache");
-    cache = {
-      hit: readOptionalBoolean(cacheRecord.hit, source, "_cache.hit"),
-      source: readOptionalString(cacheRecord.source, source, "_cache.source"),
-      reason: readOptionalString(cacheRecord.reason, source, "_cache.reason"),
-    };
-  }
-
-  return { buildings, ...(cache ? { _cache: cache } : {}) };
+  return parseExternal(
+    academicAvailabilitySchema,
+    value,
+    "academic availability",
+  );
 }
 
 export function parseReservationResponse(value: unknown): ReservationResponse {
-  const source = "LibCal";
-  const root = readRecord(value, source, "root");
-  const slots = readArray(root.slots, source, "slots").map(
-    (slotValue, index): ReservationSlot => {
-      const path = `slots[${index}]`;
-      const slot = readRecord(slotValue, source, path);
-      return {
-        itemId: readNumber(slot.itemId, source, `${path}.itemId`),
-        start: readString(slot.start, source, `${path}.start`),
-        end: readString(slot.end, source, `${path}.end`),
-        className: readOptionalString(
-          slot.className,
-          source,
-          `${path}.className`,
-        ),
-      };
-    },
-  );
-
-  return { slots };
+  return parseExternal(reservationResponseSchema, value, "LibCal");
 }
 
 export function parseRoomSchedule(value: unknown): RoomScheduleBlock[] {
-  const source = "room schedule";
-
-  return readArray(value, source, "root").map((blockValue, index) => {
-    const path = `blocks[${index}]`;
-    const block = readRecord(blockValue, source, path);
-    const status = readString(block.status, source, `${path}.status`);
-    if (status !== "available" && status !== "class" && status !== "event") {
-      throw new ExternalResponseError(
-        source,
-        `${path}.status`,
-        '"available", "class", or "event"',
-      );
-    }
-
-    let details: RoomScheduleBlock["details"] = null;
-    if (block.details !== null && block.details !== undefined) {
-      const detailRecord = readRecord(
-        block.details,
-        source,
-        `${path}.details`,
-      );
-      const type = readString(
-        detailRecord.type,
-        source,
-        `${path}.details.type`,
-      );
-      if (type !== "class" && type !== "event") {
-        throw new ExternalResponseError(
-          source,
-          `${path}.details.type`,
-          '"class" or "event"',
-        );
-      }
-
-      details = {
-        type,
-        title: readString(
-          detailRecord.title,
-          source,
-          `${path}.details.title`,
-        ),
-        course: readOptionalString(
-          detailRecord.course,
-          source,
-          `${path}.details.course`,
-        ),
-        identifier: readOptionalString(
-          detailRecord.identifier,
-          source,
-          `${path}.details.identifier`,
-        ),
-      };
-    }
-
-    return {
-      start: readString(block.start, source, `${path}.start`),
-      end: readString(block.end, source, `${path}.end`),
-      status,
-      details,
-    };
-  });
+  return parseExternal(roomScheduleSchema, value, "room schedule");
 }

--- a/src/server/services/external-contracts.ts
+++ b/src/server/services/external-contracts.ts
@@ -1,0 +1,372 @@
+import type {
+  ClassInfo,
+  ReservationResponse,
+  ReservationSlot,
+  RoomScheduleBlock,
+} from "../../types";
+
+type JsonRecord = Record<string, unknown>;
+
+export class ExternalResponseError extends Error {
+  constructor(source: string, path: string, expectation: string) {
+    super(`Invalid ${source} response at ${path}: expected ${expectation}`);
+    this.name = "ExternalResponseError";
+  }
+}
+
+function readRecord(value: unknown, source: string, path: string): JsonRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new ExternalResponseError(source, path, "an object");
+  }
+
+  return value as JsonRecord;
+}
+
+function readArray(value: unknown, source: string, path: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new ExternalResponseError(source, path, "an array");
+  }
+
+  return value;
+}
+
+function readString(
+  value: unknown,
+  source: string,
+  path: string,
+): string {
+  if (typeof value !== "string") {
+    throw new ExternalResponseError(source, path, "a string");
+  }
+
+  return value;
+}
+
+function readNumber(
+  value: unknown,
+  source: string,
+  path: string,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new ExternalResponseError(source, path, "a finite number");
+  }
+
+  return value;
+}
+
+function readBoolean(
+  value: unknown,
+  source: string,
+  path: string,
+): boolean {
+  if (typeof value !== "boolean") {
+    throw new ExternalResponseError(source, path, "a boolean");
+  }
+
+  return value;
+}
+
+function readOptionalString(
+  value: unknown,
+  source: string,
+  path: string,
+): string | undefined {
+  return value === null || value === undefined
+    ? undefined
+    : readString(value, source, path);
+}
+
+function readOptionalNumber(
+  value: unknown,
+  source: string,
+  path: string,
+): number | undefined {
+  return value === null || value === undefined
+    ? undefined
+    : readNumber(value, source, path);
+}
+
+function readOptionalBoolean(
+  value: unknown,
+  source: string,
+  path: string,
+): boolean | undefined {
+  return value === null || value === undefined
+    ? undefined
+    : readBoolean(value, source, path);
+}
+
+function parseClassInfo(
+  value: unknown,
+  source: string,
+  path: string,
+): ClassInfo | undefined {
+  if (value === null || value === undefined) return undefined;
+
+  const record = readRecord(value, source, path);
+  const course = readOptionalString(record.course, source, `${path}.course`);
+  const title = readString(record.title, source, `${path}.title`);
+  let time: ClassInfo["time"];
+
+  if (record.time !== null && record.time !== undefined) {
+    const timeRecord = readRecord(record.time, source, `${path}.time`);
+    time = {
+      start: readString(timeRecord.start, source, `${path}.time.start`),
+      end: readString(timeRecord.end, source, `${path}.time.end`),
+    };
+  }
+
+  return {
+    ...record,
+    course: course ?? "",
+    title,
+    ...(time ? { time } : {}),
+  };
+}
+
+export interface AcademicBuildingPayload {
+  name: string;
+  coordinates: { latitude: number; longitude: number };
+  hours: { open: string; close: string };
+  rooms: Record<string, AcademicRoomPayload>;
+  isOpen: boolean;
+  roomCounts: { available: number; total: number };
+}
+
+export interface AcademicRoomPayload {
+  status: "available" | "occupied";
+  passingPeriod?: boolean;
+  availableAt?: string;
+  availableFor?: number;
+  availableUntil?: string;
+  currentClass?: ClassInfo;
+  nextClass?: ClassInfo;
+}
+
+export interface AcademicAvailabilityPayload {
+  _cache?: {
+    hit?: boolean;
+    source?: string;
+    reason?: string;
+  };
+  buildings: Record<string, AcademicBuildingPayload>;
+}
+
+function parseAcademicRoom(
+  value: unknown,
+  path: string,
+): AcademicRoomPayload {
+  const source = "academic availability";
+  const record = readRecord(value, source, path);
+  const status = readString(record.status, source, `${path}.status`);
+  if (status !== "available" && status !== "occupied") {
+    throw new ExternalResponseError(
+      source,
+      `${path}.status`,
+      '"available" or "occupied"',
+    );
+  }
+
+  return {
+    status,
+    passingPeriod: readOptionalBoolean(
+      record.passingPeriod,
+      source,
+      `${path}.passingPeriod`,
+    ),
+    availableAt: readOptionalString(
+      record.availableAt,
+      source,
+      `${path}.availableAt`,
+    ),
+    availableFor: readOptionalNumber(
+      record.availableFor,
+      source,
+      `${path}.availableFor`,
+    ),
+    availableUntil: readOptionalString(
+      record.availableUntil,
+      source,
+      `${path}.availableUntil`,
+    ),
+    currentClass: parseClassInfo(
+      record.currentClass,
+      source,
+      `${path}.currentClass`,
+    ),
+    nextClass: parseClassInfo(
+      record.nextClass,
+      source,
+      `${path}.nextClass`,
+    ),
+  };
+}
+
+export function parseAcademicAvailabilityPayload(
+  value: unknown,
+): AcademicAvailabilityPayload {
+  const source = "academic availability";
+  const root = readRecord(value, source, "root");
+  const buildingsRecord = readRecord(root.buildings, source, "buildings");
+  const buildings: Record<string, AcademicBuildingPayload> = {};
+
+  for (const [buildingId, buildingValue] of Object.entries(buildingsRecord)) {
+    const path = `buildings.${buildingId}`;
+    const building = readRecord(buildingValue, source, path);
+    const coordinates = readRecord(
+      building.coordinates,
+      source,
+      `${path}.coordinates`,
+    );
+    const hours = readRecord(building.hours, source, `${path}.hours`);
+    const roomCounts = readRecord(
+      building.roomCounts,
+      source,
+      `${path}.roomCounts`,
+    );
+    const roomsRecord = readRecord(building.rooms, source, `${path}.rooms`);
+    const rooms: AcademicBuildingPayload["rooms"] = {};
+
+    for (const [roomNumber, roomValue] of Object.entries(roomsRecord)) {
+      rooms[roomNumber] = parseAcademicRoom(
+        roomValue,
+        `${path}.rooms.${roomNumber}`,
+      );
+    }
+
+    buildings[buildingId] = {
+      name: readString(building.name, source, `${path}.name`),
+      coordinates: {
+        latitude: readNumber(
+          coordinates.latitude,
+          source,
+          `${path}.coordinates.latitude`,
+        ),
+        longitude: readNumber(
+          coordinates.longitude,
+          source,
+          `${path}.coordinates.longitude`,
+        ),
+      },
+      hours: {
+        open:
+          readOptionalString(hours.open, source, `${path}.hours.open`) ?? "",
+        close:
+          readOptionalString(hours.close, source, `${path}.hours.close`) ?? "",
+      },
+      rooms,
+      isOpen: readBoolean(building.isOpen, source, `${path}.isOpen`),
+      roomCounts: {
+        available: readNumber(
+          roomCounts.available,
+          source,
+          `${path}.roomCounts.available`,
+        ),
+        total: readNumber(
+          roomCounts.total,
+          source,
+          `${path}.roomCounts.total`,
+        ),
+      },
+    };
+  }
+
+  let cache: AcademicAvailabilityPayload["_cache"];
+  if (root._cache !== null && root._cache !== undefined) {
+    const cacheRecord = readRecord(root._cache, source, "_cache");
+    cache = {
+      hit: readOptionalBoolean(cacheRecord.hit, source, "_cache.hit"),
+      source: readOptionalString(cacheRecord.source, source, "_cache.source"),
+      reason: readOptionalString(cacheRecord.reason, source, "_cache.reason"),
+    };
+  }
+
+  return { buildings, ...(cache ? { _cache: cache } : {}) };
+}
+
+export function parseReservationResponse(value: unknown): ReservationResponse {
+  const source = "LibCal";
+  const root = readRecord(value, source, "root");
+  const slots = readArray(root.slots, source, "slots").map(
+    (slotValue, index): ReservationSlot => {
+      const path = `slots[${index}]`;
+      const slot = readRecord(slotValue, source, path);
+      return {
+        itemId: readNumber(slot.itemId, source, `${path}.itemId`),
+        start: readString(slot.start, source, `${path}.start`),
+        end: readString(slot.end, source, `${path}.end`),
+        className: readOptionalString(
+          slot.className,
+          source,
+          `${path}.className`,
+        ),
+      };
+    },
+  );
+
+  return { slots };
+}
+
+export function parseRoomSchedule(value: unknown): RoomScheduleBlock[] {
+  const source = "room schedule";
+
+  return readArray(value, source, "root").map((blockValue, index) => {
+    const path = `blocks[${index}]`;
+    const block = readRecord(blockValue, source, path);
+    const status = readString(block.status, source, `${path}.status`);
+    if (status !== "available" && status !== "class" && status !== "event") {
+      throw new ExternalResponseError(
+        source,
+        `${path}.status`,
+        '"available", "class", or "event"',
+      );
+    }
+
+    let details: RoomScheduleBlock["details"] = null;
+    if (block.details !== null && block.details !== undefined) {
+      const detailRecord = readRecord(
+        block.details,
+        source,
+        `${path}.details`,
+      );
+      const type = readString(
+        detailRecord.type,
+        source,
+        `${path}.details.type`,
+      );
+      if (type !== "class" && type !== "event") {
+        throw new ExternalResponseError(
+          source,
+          `${path}.details.type`,
+          '"class" or "event"',
+        );
+      }
+
+      details = {
+        type,
+        title: readString(
+          detailRecord.title,
+          source,
+          `${path}.details.title`,
+        ),
+        course: readOptionalString(
+          detailRecord.course,
+          source,
+          `${path}.details.course`,
+        ),
+        identifier: readOptionalString(
+          detailRecord.identifier,
+          source,
+          `${path}.details.identifier`,
+        ),
+      };
+    }
+
+    return {
+      start: readString(block.start, source, `${path}.start`),
+      end: readString(block.end, source, `${path}.end`),
+      status,
+      details,
+    };
+  });
+}

--- a/src/server/services/facilities.test.ts
+++ b/src/server/services/facilities.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import moment from "moment-timezone";
+import { FacilityType, RoomStatus } from "../../types";
+import { getFacilityStatus, type FacilitiesFetch } from "./facilities";
+
+const CAMPUS_TIMEZONE = "America/Chicago";
+
+describe("getFacilityStatus", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("maps the academic RPC contract into room availability", async () => {
+    const target = moment.tz(
+      "2026-08-24 10:00:00",
+      "YYYY-MM-DD HH:mm:ss",
+      CAMPUS_TIMEZONE,
+    );
+    const rpcCalls: unknown[] = [];
+    const unexpectedFetch: FacilitiesFetch = async () => {
+      throw new Error("LibCal should not be called for academic scope");
+    };
+
+    const result = await getFacilityStatus(target, "academic", {
+      fetch: unexpectedFetch,
+      executeAcademicAvailabilityRpc: async (procedure, parameters) => {
+        rpcCalls.push({ procedure, parameters });
+        return {
+          data: {
+            _cache: { hit: true, source: "room_availability_cache" },
+            buildings: {
+              siebel: {
+                name: "Siebel Center",
+                coordinates: { latitude: 40.114, longitude: -88.224 },
+                hours: { open: "08:00:00", close: "22:00:00" },
+                isOpen: true,
+                roomCounts: { available: 2, total: 4 },
+                rooms: {
+                  "1101": {
+                    status: "available",
+                    passingPeriod: false,
+                    availableFor: 90,
+                  },
+                  "1102": {
+                    status: "available",
+                    passingPeriod: true,
+                    availableFor: 10,
+                  },
+                  "1103": {
+                    status: "occupied",
+                    availableAt: "10:15:00",
+                    availableFor: 45,
+                  },
+                  "1104": {
+                    status: "occupied",
+                    availableAt: "11:00:00",
+                    availableFor: -5,
+                  },
+                },
+              },
+            },
+          },
+          error: null,
+        };
+      },
+    });
+
+    expect(rpcCalls).toEqual([
+      {
+        procedure: "get_cached_spots",
+        parameters: {
+          check_time_param: "10:00:00",
+          check_date_param: "2026-08-24",
+          min_minutes_param: 30,
+        },
+      },
+    ]);
+    expect(result.timestamp).toBe(target.toISOString());
+
+    const facility = result.facilities.siebel;
+    expect(facility.type).toBe(FacilityType.ACADEMIC);
+    expect(facility.rooms["1101"].status).toBe(RoomStatus.AVAILABLE);
+    expect(facility.rooms["1102"].status).toBe(RoomStatus.PASSING_PERIOD);
+    expect(facility.rooms["1103"].status).toBe(RoomStatus.OPENING_SOON);
+    expect(facility.rooms["1104"]).toMatchObject({
+      status: RoomStatus.OCCUPIED,
+      availableFor: 0,
+    });
+  });
+
+  it("maps LibCal slots into current, upcoming, and unavailable rooms", async () => {
+    const target = moment.tz(
+      "2026-08-24 08:15:00",
+      "YYYY-MM-DD HH:mm:ss",
+      CAMPUS_TIMEZONE,
+    );
+    const requests: Array<{ url: string; body: URLSearchParams }> = [];
+    const fetchLibCal: FacilitiesFetch = async (input, init) => {
+      requests.push({
+        url: String(input),
+        body: new URLSearchParams(String(init?.body)),
+      });
+
+      return Response.json({
+        slots: [
+          {
+            itemId: 25428,
+            start: "2026-08-24 08:00:00",
+            end: "2026-08-24 09:00:00",
+          },
+          {
+            itemId: 25436,
+            start: "2026-08-24 08:00:00",
+            end: "2026-08-24 08:30:00",
+            className: "s-lc-eq-checkout",
+          },
+          {
+            itemId: 25436,
+            start: "2026-08-24 08:30:00",
+            end: "2026-08-24 09:30:00",
+          },
+        ],
+      });
+    };
+    const unexpectedRpc = async () => {
+      throw new Error("Supabase should not be called for library scope");
+    };
+
+    const result = await getFacilityStatus(target, "library", {
+      fetch: fetchLibCal,
+      executeAcademicAvailabilityRpc: unexpectedRpc,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toBe(
+      "https://libcal.library.illinois.edu/spaces/availability/grid",
+    );
+    expect(Object.fromEntries(requests[0].body)).toMatchObject({
+      lid: "3606",
+      start: "2026-08-24",
+      end: "2026-08-25",
+      pageSize: "10000",
+    });
+
+    const grainger = result.facilities["Grainger Engineering Library"];
+    expect(grainger).toMatchObject({
+      isOpen: true,
+      roomCounts: { available: 1, total: 9 },
+    });
+    expect(grainger.rooms["405"]).toMatchObject({
+      status: RoomStatus.AVAILABLE,
+      availableFor: 45,
+    });
+    expect(grainger.rooms["407"]).toMatchObject({
+      status: RoomStatus.OPENING_SOON,
+      availableAt: "08:30:00",
+      availableFor: 60,
+    });
+    expect(grainger.rooms["408 collaboration"].status).toBe(
+      RoomStatus.UNAVAILABLE,
+    );
+  });
+
+  it("requests the additional calendar day needed for Funk's overnight hours", async () => {
+    const target = moment.tz(
+      "2026-08-24 22:30:00",
+      "YYYY-MM-DD HH:mm:ss",
+      CAMPUS_TIMEZONE,
+    );
+    const requestWindows: Record<string, { start: string; end: string }> = {};
+    const fetchLibCal: FacilitiesFetch = async (_input, init) => {
+      const body = new URLSearchParams(String(init?.body));
+      requestWindows[body.get("lid") ?? "unknown"] = {
+        start: body.get("start") ?? "",
+        end: body.get("end") ?? "",
+      };
+      return Response.json({ slots: [] });
+    };
+
+    await getFacilityStatus(target, "library", { fetch: fetchLibCal });
+
+    expect(requestWindows).toEqual({
+      "3604": { start: "2026-08-24", end: "2026-08-26" },
+      "3606": { start: "2026-08-24", end: "2026-08-25" },
+    });
+  });
+
+  it("preserves other facility results when one LibCal request times out", async () => {
+    spyOn(console, "error").mockImplementation(() => {});
+    const target = moment.tz(
+      "2026-08-24 10:00:00",
+      "YYYY-MM-DD HH:mm:ss",
+      CAMPUS_TIMEZONE,
+    );
+    const partiallyTimedOutFetch: FacilitiesFetch = async (
+      _input,
+      init,
+    ) => {
+      const lid = new URLSearchParams(String(init?.body)).get("lid");
+      if (lid === "3604") {
+        throw new DOMException("The operation timed out", "TimeoutError");
+      }
+
+      return Response.json({
+        slots:
+          lid === "3606"
+            ? [
+                {
+                  itemId: 25428,
+                  start: "2026-08-24 10:00:00",
+                  end: "2026-08-24 11:00:00",
+                },
+              ]
+            : [],
+      });
+    };
+
+    const result = await getFacilityStatus(target, "all", {
+      fetch: partiallyTimedOutFetch,
+      executeAcademicAvailabilityRpc: async () => ({
+        data: {
+          buildings: {
+            cif: {
+              name: "Campus Instructional Facility",
+              coordinates: { latitude: 40.0, longitude: -88.0 },
+              hours: { open: "07:00:00", close: "22:00:00" },
+              isOpen: true,
+              roomCounts: { available: 0, total: 0 },
+              rooms: {},
+            },
+          },
+        },
+        error: null,
+      }),
+    });
+
+    expect(result.facilities.cif.name).toBe(
+      "Campus Instructional Facility",
+    );
+    expect(result.facilities["Grainger Engineering Library"].roomCounts).toEqual(
+      { available: 1, total: 9 },
+    );
+    expect(result.facilities["Funk ACES Library"]).toMatchObject({
+      roomCounts: { available: 0, total: 0 },
+      rooms: {},
+    });
+  });
+});

--- a/src/server/services/facilities.test.ts
+++ b/src/server/services/facilities.test.ts
@@ -88,6 +88,24 @@ describe("getFacilityStatus", () => {
     });
   });
 
+  it("rejects malformed academic responses instead of returning invalid facilities", async () => {
+    spyOn(console, "error").mockImplementation(() => {});
+    const target = moment.tz(
+      "2026-08-24 10:00:00",
+      "YYYY-MM-DD HH:mm:ss",
+      CAMPUS_TIMEZONE,
+    );
+
+    const result = await getFacilityStatus(target, "academic", {
+      executeAcademicAvailabilityRpc: async () => ({
+        data: { buildings: { malformed: {} } },
+        error: null,
+      }),
+    });
+
+    expect(result.facilities).toEqual({});
+  });
+
   it("maps LibCal slots into current, upcoming, and unavailable rooms", async () => {
     const target = moment.tz(
       "2026-08-24 08:15:00",
@@ -185,6 +203,36 @@ describe("getFacilityStatus", () => {
     });
   });
 
+  it("caps overnight availability at the active interval's closing time", async () => {
+    const target = moment.tz(
+      "2026-08-25 01:30:00",
+      "YYYY-MM-DD HH:mm:ss",
+      CAMPUS_TIMEZONE,
+    );
+    const fetchLibCal: FacilitiesFetch = async () =>
+      Response.json({
+        slots: [
+          {
+            itemId: 23939,
+            start: "2026-08-25 01:00:00",
+            end: "2026-08-25 03:00:00",
+          },
+        ],
+      });
+
+    const result = await getFacilityStatus(target, "library", {
+      fetch: fetchLibCal,
+    });
+
+    expect(result.facilities["Funk ACES Library"].rooms["301"]).toMatchObject({
+      status: RoomStatus.AVAILABLE,
+      availableFor: 30,
+      slots: [
+        { start: "01:00:00", end: "02:00:00", available: true },
+      ],
+    });
+  });
+
   it("preserves other facility results when one LibCal request times out", async () => {
     spyOn(console, "error").mockImplementation(() => {});
     const target = moment.tz(
@@ -240,9 +288,6 @@ describe("getFacilityStatus", () => {
     expect(result.facilities["Grainger Engineering Library"].roomCounts).toEqual(
       { available: 1, total: 9 },
     );
-    expect(result.facilities["Funk ACES Library"]).toMatchObject({
-      roomCounts: { available: 0, total: 0 },
-      rooms: {},
-    });
+    expect(result.facilities["Funk ACES Library"]).toBeUndefined();
   });
 });

--- a/src/server/services/facilities.ts
+++ b/src/server/services/facilities.ts
@@ -24,12 +24,55 @@ import {
 
 const LIBCAL_REQUEST_TIMEOUT_MS = 10_000;
 
+export interface AcademicAvailabilityPayload {
+  _cache?: {
+    hit?: boolean;
+    source?: string;
+    reason?: string;
+  };
+  buildings?: Record<string, unknown>;
+}
+
+export interface AcademicAvailabilityRpcResult {
+  data: AcademicAvailabilityPayload | null;
+  error: unknown;
+}
+
+export interface AcademicAvailabilityRpcParameters {
+  check_time_param: string;
+  check_date_param: string;
+  min_minutes_param: number;
+}
+
+export type FacilitiesFetch = (
+  ...arguments_: Parameters<typeof globalThis.fetch>
+) => ReturnType<typeof globalThis.fetch>;
+
+export interface FacilitiesServiceDependencies {
+  fetch?: FacilitiesFetch;
+  executeAcademicAvailabilityRpc?: (
+    procedure: "get_cached_spots",
+    parameters: AcademicAvailabilityRpcParameters,
+  ) => Promise<AcademicAvailabilityRpcResult>;
+}
+
+async function executeAcademicAvailabilityRpc(
+  procedure: "get_cached_spots",
+  parameters: AcademicAvailabilityRpcParameters,
+): Promise<AcademicAvailabilityRpcResult> {
+  const supabaseConfig = getSupabaseConfig();
+  const supabase = createClient(supabaseConfig.url, supabaseConfig.key);
+
+  return await supabase.rpc(procedure, parameters);
+}
+
 /**
  * Retrieves reservation data for a specific library for the relevant date(s)
  */
 async function getReservation(
   lid: string,
   targetMoment: moment.Moment,
+  fetcher: FacilitiesFetch,
 ): Promise<ReservationResponse> {
   const url = "https://libcal.library.illinois.edu/spaces/availability/grid";
   const timezone = "America/Chicago";
@@ -75,7 +118,7 @@ async function getReservation(
       attributes: { "library.id": lid },
     },
     () =>
-      fetch(url, {
+      fetcher(url, {
         method: "POST",
         headers,
         body: new URLSearchParams(payload),
@@ -415,6 +458,7 @@ function linkRoomsReservations(
 async function getFormattedLibraryData(
   openLibraries: string[], // Libraries determined to be open at targetMoment
   targetMoment: moment.Moment, // Use targetMoment
+  fetcher: FacilitiesFetch,
 ): Promise<FormattedLibraryData> {
   const result: FormattedLibraryData = {};
 
@@ -422,21 +466,24 @@ async function getFormattedLibraryData(
     return result; // No open libraries to process
   }
 
-  try {
-    // Process only the libraries that are open at targetMoment
-    const libraryPromises = openLibraries.map(async (libraryName) => {
+  // Process only the libraries that are open at targetMoment. Keep failures
+  // isolated so one unavailable LibCal calendar does not erase other results.
+  const libraryPromises = openLibraries.map(async (libraryName) => {
+    try {
       const libraryInfo = LIBRARIES[libraryName];
       if (!libraryInfo) return null; // Should not happen if openLibraries is correct
 
       const lid = libraryInfo.id;
       const libraryRooms = STATIC_ROOMS_BY_LIBRARY[lid] || [];
       if (libraryRooms.length === 0) {
-        console.warn(`No static room metadata found for library ${libraryName} (lid ${lid})`);
+        console.warn(
+          `No static room metadata found for library ${libraryName} (lid ${lid})`,
+        );
         return null;
       }
 
       // Get reservation data relevant to the targetMoment
-      const reservationData = await getReservation(lid, targetMoment);
+      const reservationData = await getReservation(lid, targetMoment, fetcher);
       // Link reservations using targetMoment
       const roomReservations = linkRoomsReservations(
         libraryRooms,
@@ -461,24 +508,27 @@ async function getFormattedLibraryData(
           address: libraryInfo.address,
         },
       };
-    });
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: "libcal",
+          operation: "fetch-availability",
+          library: libraryName,
+        },
+      });
+      Sentry.getActiveSpan()?.setAttribute("result.partial", true);
+      console.error(`Error fetching library data for ${libraryName}:`, error);
+      return null;
+    }
+  });
 
-    const libraryResults = await Promise.all(libraryPromises);
+  const libraryResults = await Promise.all(libraryPromises);
 
-    // Combine results
-    libraryResults.forEach((libraryResult) => {
-      if (libraryResult) {
-        result[libraryResult.libraryName] = libraryResult.data;
-      }
-    });
-  } catch (error) {
-    Sentry.captureException(error, {
-      tags: { component: "libcal", operation: "fetch-availability" },
-    });
-    Sentry.getActiveSpan()?.setAttribute("result.partial", true);
-    console.error("Error fetching library data:", error);
-    // Consider how to handle partial errors if needed
-  }
+  libraryResults.forEach((libraryResult) => {
+    if (libraryResult) {
+      result[libraryResult.libraryName] = libraryResult.data;
+    }
+  });
 
   return result;
 }
@@ -490,34 +540,26 @@ async function getFormattedLibraryData(
  */
 async function fetchAcademicBuildingData(
   targetMoment: moment.Moment,
+  executeRpc: NonNullable<
+    FacilitiesServiceDependencies["executeAcademicAvailabilityRpc"]
+  >,
 ): Promise<Record<string, Facility>> {
   const facilities: Record<string, Facility> = {};
 
   try {
-    const supabaseConfig = getSupabaseConfig();
-    const supabase = createClient(supabaseConfig.url, supabaseConfig.key);
-
     const { data: buildingData, error } = await Sentry.startSpan(
       {
         name: "Supabase RPC get_cached_spots",
         op: "db.rpc",
       },
       async (span) => {
-        const response = await supabase.rpc("get_cached_spots", {
+        const response = await executeRpc("get_cached_spots", {
           check_time_param: targetMoment.format("HH:mm:ss"),
           check_date_param: targetMoment.format("YYYY-MM-DD"),
           min_minutes_param: 30,
         });
 
-        const cacheMetadata = (
-          response.data as {
-            _cache?: {
-              hit?: boolean;
-              source?: string;
-              reason?: string;
-            };
-          } | null
-        )?._cache;
+        const cacheMetadata = response.data?._cache;
         const cacheResult = response.error
           ? "error"
           : cacheMetadata?.hit === true
@@ -701,6 +743,7 @@ function initializeLibraryFacilities(): Record<string, Facility> {
 async function updateLibraryFacilities(
   libraryFacilities: Record<string, Facility>,
   targetMoment: moment.Moment, // Use targetMoment
+  fetcher: FacilitiesFetch,
 ): Promise<Record<string, Facility>> {
   try {
     // Update each library's isOpen status based on the targetMoment
@@ -724,6 +767,7 @@ async function updateLibraryFacilities(
       const libraryData = await getFormattedLibraryData(
         openLibraryNames,
         targetMoment,
+        fetcher,
       );
 
       // Add room data only for libraries that are open AT targetMoment
@@ -772,6 +816,7 @@ export type FacilityScope = "academic" | "library" | "all";
 export async function getFacilityStatus(
   targetMoment: moment.Moment,
   facilityScope: FacilityScope,
+  dependencies: FacilitiesServiceDependencies = {},
 ): Promise<FacilityStatus> {
   const includeAcademic =
     facilityScope === "all" || facilityScope === "academic";
@@ -779,14 +824,22 @@ export async function getFacilityStatus(
     facilityScope === "all" || facilityScope === "library";
 
   const fetchPromises: Promise<Record<string, Facility>>[] = [];
+  const fetcher = dependencies.fetch ?? globalThis.fetch;
+  const executeRpc =
+    dependencies.executeAcademicAvailabilityRpc ??
+    executeAcademicAvailabilityRpc;
 
   if (includeAcademic) {
-    fetchPromises.push(fetchAcademicBuildingData(targetMoment));
+    fetchPromises.push(fetchAcademicBuildingData(targetMoment, executeRpc));
   }
 
   if (includeLibraries) {
     fetchPromises.push(
-      updateLibraryFacilities(initializeLibraryFacilities(), targetMoment),
+      updateLibraryFacilities(
+        initializeLibraryFacilities(),
+        targetMoment,
+        fetcher,
+      ),
     );
   }
 

--- a/src/server/services/facilities.ts
+++ b/src/server/services/facilities.ts
@@ -14,27 +14,27 @@ import {
   LibraryRoom,
   RoomReservation,
 } from "../../types";
-import { isLibraryOpen, LIBRARY_HOURS } from "../../utils/libraryHours";
+import {
+  getActiveLibraryHours,
+  isLibraryOpen,
+  LIBRARY_HOURS,
+} from "../../utils/libraryHours";
 import { getSupabaseConfig } from "../config";
 import { Sentry } from "../observability";
 import {
   LIBRARIES,
   STATIC_ROOMS_BY_LIBRARY,
 } from "../data/library-catalog";
+import {
+  parseAcademicAvailabilityPayload,
+  parseReservationResponse,
+  type AcademicAvailabilityPayload,
+} from "./external-contracts";
 
 const LIBCAL_REQUEST_TIMEOUT_MS = 10_000;
 
-export interface AcademicAvailabilityPayload {
-  _cache?: {
-    hit?: boolean;
-    source?: string;
-    reason?: string;
-  };
-  buildings?: Record<string, unknown>;
-}
-
 export interface AcademicAvailabilityRpcResult {
-  data: AcademicAvailabilityPayload | null;
+  data: unknown;
   error: unknown;
 }
 
@@ -132,7 +132,7 @@ async function getReservation(
     );
   }
 
-  return (await response.json()) as ReservationResponse;
+  return parseReservationResponse(await response.json());
 }
 
 /**
@@ -222,36 +222,6 @@ const isOpeningSoon = (
 };
 
 /**
- * Gets the closing time moment object for a library on a specific date.
- * Returns null if hours are not defined or invalid.
- */
-function getLibraryClosingTime(
-  libraryName: string,
-  targetDate: moment.Moment,
-): moment.Moment | null {
-  const timezone = "America/Chicago";
-  const dayOfWeek = targetDate.format("dddd");
-  const hours = LIBRARY_HOURS[libraryName]?.[dayOfWeek];
-
-  if (!hours || !hours.close) {
-    return null;
-  }
-
-  const closingMoment = moment.tz(
-    `${targetDate.format("YYYY-MM-DD")} ${hours.close}`,
-    "YYYY-MM-DD HH:mm", // Assume HH:mm format from LIBRARY_HOURS
-    timezone,
-  );
-
-  // If the closing time is on the next day (e.g., 02:00), add a day
-  if (hours.nextDay) {
-    closingMoment.add(1, "day");
-  }
-
-  return closingMoment.isValid() ? closingMoment : null;
-}
-
-/**
  * Links room data with reservation data to create a complete picture of room availability at a specific time
  */
 function linkRoomsReservations(
@@ -264,7 +234,6 @@ function linkRoomsReservations(
     Object.values(LIBRARIES).map((lib) => parseInt(lib.id)),
   );
   const timezone = "America/Chicago";
-  const targetDateCST = targetMoment.clone().tz(timezone).startOf("day");
   const targetMomentString = targetMoment.format("YYYY-MM-DD HH:mm:ss");
 
   for (const room of roomsData) {
@@ -281,11 +250,10 @@ function linkRoomsReservations(
     let isCurrentlyAvailable = false;
     let roomStatus: RoomStatus = RoomStatus.RESERVED; // Default status
 
-    // Determine the relevant closing time for this library on the target date
-    const libraryClosingTime = getLibraryClosingTime(
+    const libraryClosingTime = getActiveLibraryHours(
       libraryName,
-      targetDateCST,
-    );
+      targetMoment,
+    )?.close ?? null;
 
     // Filter slots relevant to the room and sort them
     const roomSpecificSlots = reservationsData.slots
@@ -469,45 +437,21 @@ async function getFormattedLibraryData(
   // Process only the libraries that are open at targetMoment. Keep failures
   // isolated so one unavailable LibCal calendar does not erase other results.
   const libraryPromises = openLibraries.map(async (libraryName) => {
-    try {
-      const libraryInfo = LIBRARIES[libraryName];
-      if (!libraryInfo) return null; // Should not happen if openLibraries is correct
+    const libraryInfo = LIBRARIES[libraryName];
+    if (!libraryInfo) return null; // Should not happen if openLibraries is correct
 
-      const lid = libraryInfo.id;
-      const libraryRooms = STATIC_ROOMS_BY_LIBRARY[lid] || [];
-      if (libraryRooms.length === 0) {
-        console.warn(
-          `No static room metadata found for library ${libraryName} (lid ${lid})`,
-        );
-        return null;
-      }
-
-      // Get reservation data relevant to the targetMoment
-      const reservationData = await getReservation(lid, targetMoment, fetcher);
-      // Link reservations using targetMoment
-      const roomReservations = linkRoomsReservations(
-        libraryRooms,
-        reservationData,
-        targetMoment,
+    const lid = libraryInfo.id;
+    const libraryRooms = STATIC_ROOMS_BY_LIBRARY[lid] || [];
+    if (libraryRooms.length === 0) {
+      console.warn(
+        `No static room metadata found for library ${libraryName} (lid ${lid})`,
       );
+      return null;
+    }
 
-      // Count available rooms AT targetMoment based on the status set by linkRoomsReservations
-      let availableCount = 0;
-      for (const room of Object.values(roomReservations)) {
-        if (room.status === RoomStatus.AVAILABLE) {
-          availableCount++;
-        }
-      }
-
-      return {
-        libraryName,
-        data: {
-          room_count: Object.keys(roomReservations).length,
-          currently_available: availableCount, // Reflects availability AT targetMoment
-          rooms: roomReservations,
-          address: libraryInfo.address,
-        },
-      };
+    let reservationData: ReservationResponse;
+    try {
+      reservationData = await getReservation(lid, targetMoment, fetcher);
     } catch (error) {
       Sentry.captureException(error, {
         tags: {
@@ -520,6 +464,25 @@ async function getFormattedLibraryData(
       console.error(`Error fetching library data for ${libraryName}:`, error);
       return null;
     }
+
+    const roomReservations = linkRoomsReservations(
+      libraryRooms,
+      reservationData,
+      targetMoment,
+    );
+    const availableCount = Object.values(roomReservations).filter(
+      (room) => room.status === RoomStatus.AVAILABLE,
+    ).length;
+
+    return {
+      libraryName,
+      data: {
+        room_count: Object.keys(roomReservations).length,
+        currently_available: availableCount,
+        rooms: roomReservations,
+        address: libraryInfo.address,
+      },
+    };
   });
 
   const libraryResults = await Promise.all(libraryPromises);
@@ -545,9 +508,10 @@ async function fetchAcademicBuildingData(
   >,
 ): Promise<Record<string, Facility>> {
   const facilities: Record<string, Facility> = {};
+  let buildingData: AcademicAvailabilityPayload;
 
   try {
-    const { data: buildingData, error } = await Sentry.startSpan(
+    const { data, error } = await Sentry.startSpan(
       {
         name: "Supabase RPC get_cached_spots",
         op: "db.rpc",
@@ -559,7 +523,10 @@ async function fetchAcademicBuildingData(
           min_minutes_param: 30,
         });
 
-        const cacheMetadata = response.data?._cache;
+        const parsedData = response.error
+          ? null
+          : parseAcademicAvailabilityPayload(response.data);
+        const cacheMetadata = parsedData?._cache;
         const cacheResult = response.error
           ? "error"
           : cacheMetadata?.hit === true
@@ -592,7 +559,7 @@ async function fetchAcademicBuildingData(
           console.warn("Cache telemetry failed:", telemetryError);
         }
 
-        return response;
+        return { data: parsedData, error: response.error };
       },
     );
 
@@ -604,85 +571,67 @@ async function fetchAcademicBuildingData(
       console.error("Error fetching building data from Supabase:", error);
       return facilities; // Return empty on error
     }
-
-    // Process Supabase response
-    if (buildingData?.buildings) {
-      Object.entries(buildingData.buildings).forEach(([id, buildingInfo]) => {
-        const building = buildingInfo as {
-          name: string;
-          coordinates: { latitude: number; longitude: number };
-          hours: { open: string; close: string };
-          rooms: Record<
-            string,
-            Omit<AcademicRoom, "type" | "status"> & {
-              status: "available" | "occupied";
-              passingPeriod?: boolean;
-              availableAt?: string;
-              availableFor?: number;
-              availableUntil?: string;
-              currentClass?: any;
-              nextClass?: any;
-            }
-          >;
-          isOpen: boolean;
-          roomCounts: { available: number; total: number }; // Counts based on check_time
-        };
-
-        const academicFacility: Facility = {
-          id,
-          name: building.name,
-          type: FacilityType.ACADEMIC,
-          coordinates: building.coordinates,
-          hours: building.hours, // These hours are for the *day*
-          isOpen: building.isOpen, // This reflects if open AT targetMoment
-          roomCounts: building.roomCounts || { available: 0, total: 0 }, // Counts are based on targetMoment
-          rooms: {},
-        };
-
-        Object.entries(building.rooms || {}).forEach(([roomNumber, roomData]) => {
-          let status: RoomStatus;
-          if (roomData.status === "available") {
-            if (roomData.passingPeriod) {
-              status = RoomStatus.PASSING_PERIOD;
-            } else {
-              status = RoomStatus.AVAILABLE;
-            }
-          } else {
-            if (
-              roomData.availableAt &&
-              isOpeningSoon(roomData.availableAt, targetMoment) &&
-              roomData.availableFor &&
-              roomData.availableFor >= 30
-            ) {
-              status = RoomStatus.OPENING_SOON;
-            } else {
-              status = RoomStatus.OCCUPIED;
-            }
-          }
-
-          academicFacility.rooms[roomNumber] = {
-            type: "academic",
-            status: status,
-            currentClass: roomData.currentClass,
-            nextClass: roomData.nextClass,
-            availableAt: roomData.availableAt,
-            availableFor: roomData.availableFor
-              ? Math.max(0, roomData.availableFor)
-              : undefined, // Ensure non-negative
-            availableUntil: roomData.availableUntil,
-          } as AcademicRoom;
-        });
-
-        facilities[id] = academicFacility;
-      });
+    if (!data) {
+      return facilities;
     }
+    buildingData = data;
   } catch (error) {
     Sentry.captureException(error, {
       tags: { component: "supabase", operation: "get_cached_spots" },
     });
     Sentry.getActiveSpan()?.setAttribute("result.partial", true);
-    console.error("Error in fetchAcademicBuildingData:", error);
+    console.error("Error loading academic availability:", error);
+    return facilities;
   }
+
+  Object.entries(buildingData.buildings).forEach(([id, building]) => {
+    const academicFacility: Facility = {
+      id,
+      name: building.name,
+      type: FacilityType.ACADEMIC,
+      coordinates: building.coordinates,
+      hours: building.hours,
+      isOpen: building.isOpen,
+      roomCounts: building.roomCounts,
+      rooms: {},
+    };
+
+    Object.entries(building.rooms).forEach(([roomNumber, roomData]) => {
+      let status: RoomStatus;
+      if (roomData.status === "available") {
+        if (roomData.passingPeriod) {
+          status = RoomStatus.PASSING_PERIOD;
+        } else {
+          status = RoomStatus.AVAILABLE;
+        }
+      } else {
+        if (
+          roomData.availableAt &&
+          isOpeningSoon(roomData.availableAt, targetMoment) &&
+          roomData.availableFor &&
+          roomData.availableFor >= 30
+        ) {
+          status = RoomStatus.OPENING_SOON;
+        } else {
+          status = RoomStatus.OCCUPIED;
+        }
+      }
+
+      academicFacility.rooms[roomNumber] = {
+        type: "academic",
+        status,
+        currentClass: roomData.currentClass,
+        nextClass: roomData.nextClass,
+        availableAt: roomData.availableAt,
+        availableFor: roomData.availableFor
+          ? Math.max(0, roomData.availableFor)
+          : undefined,
+        availableUntil: roomData.availableUntil,
+      } as AcademicRoom;
+    });
+
+    facilities[id] = academicFacility;
+  });
 
   return facilities;
 }
@@ -745,63 +694,56 @@ async function updateLibraryFacilities(
   targetMoment: moment.Moment, // Use targetMoment
   fetcher: FacilitiesFetch,
 ): Promise<Record<string, Facility>> {
-  try {
-    // Update each library's isOpen status based on the targetMoment
-    Object.entries(libraryFacilities).forEach(([libraryName, facility]) => {
-      facility.isOpen = isLibraryOpen(libraryName, targetMoment);
+  Object.entries(libraryFacilities).forEach(([libraryName, facility]) => {
+    facility.isOpen = isLibraryOpen(libraryName, targetMoment);
 
-      // Update facility.hours based on the day of targetMoment
-      const dayOfWeek = targetMoment.format("dddd");
-      const dailyHours = LIBRARY_HOURS[libraryName]?.[dayOfWeek];
-      facility.hours.open = dailyHours?.open ?? "";
-      facility.hours.close = dailyHours?.close ?? "";
-    });
+    const dayOfWeek = targetMoment.format("dddd");
+    const dailyHours = LIBRARY_HOURS[libraryName]?.[dayOfWeek];
+    facility.hours.open = dailyHours?.open ?? "";
+    facility.hours.close = dailyHours?.close ?? "";
+  });
 
-    // Filter libraries that are open AT targetMoment
-    const openLibraryNames = Object.entries(libraryFacilities)
-      .filter(([, facility]) => facility.isOpen)
-      .map(([name]) => name);
+  const openLibraryNames = Object.entries(libraryFacilities)
+    .filter(([, facility]) => facility.isOpen)
+    .map(([name]) => name);
 
-    if (openLibraryNames.length > 0) {
-      // Get library data for open libraries using targetMoment
-      const libraryData = await getFormattedLibraryData(
-        openLibraryNames,
-        targetMoment,
-        fetcher,
-      );
-
-      // Add room data only for libraries that are open AT targetMoment
-      Object.entries(libraryData).forEach(([name, data]) => {
-        const libraryFacility = libraryFacilities[name];
-        if (libraryFacility?.isOpen) {
-          // Update counts based on availability AT targetMoment
-          libraryFacility.roomCounts = {
-            available: data.currently_available,
-            total: data.room_count,
-          };
-
-          // Convert library rooms to FacilityRoom format using data from linkRoomsReservations
-          Object.entries(data.rooms).forEach(([roomName, roomData]) => {
-            libraryFacility.rooms[roomName] = {
-              type: "library",
-              status: roomData.status,
-              url: roomData.url,
-              thumbnail: roomData.thumbnail,
-              slots: roomData.slots,
-              availableAt: roomData.availableAt,
-              availableFor: roomData.availableDuration,
-            } as LibraryRoom;
-          });
-        }
-      });
-    }
-  } catch (error) {
-    Sentry.captureException(error, {
-      tags: { component: "libcal", operation: "update-facilities" },
-    });
-    Sentry.getActiveSpan()?.setAttribute("result.partial", true);
-    console.error("Error in updateLibraryFacilities:", error);
+  if (openLibraryNames.length === 0) {
+    return libraryFacilities;
   }
+
+  const libraryData = await getFormattedLibraryData(
+    openLibraryNames,
+    targetMoment,
+    fetcher,
+  );
+
+  for (const libraryName of openLibraryNames) {
+    if (!libraryData[libraryName]) {
+      delete libraryFacilities[libraryName];
+    }
+  }
+
+  Object.entries(libraryData).forEach(([name, data]) => {
+    const libraryFacility = libraryFacilities[name];
+    if (!libraryFacility?.isOpen) return;
+
+    libraryFacility.roomCounts = {
+      available: data.currently_available,
+      total: data.room_count,
+    };
+
+    Object.entries(data.rooms).forEach(([roomName, roomData]) => {
+      libraryFacility.rooms[roomName] = {
+        type: "library",
+        status: roomData.status,
+        url: roomData.url,
+        thumbnail: roomData.thumbnail,
+        slots: roomData.slots,
+        availableAt: roomData.availableAt,
+        availableFor: roomData.availableDuration,
+      } as LibraryRoom;
+    });
+  });
 
   return libraryFacilities;
 }

--- a/src/server/services/room-schedule.test.ts
+++ b/src/server/services/room-schedule.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { RoomScheduleBlock } from "../../types";
+import {
+  loadRoomSchedule,
+  RoomScheduleDatabaseError,
+} from "./room-schedule";
+
+describe("loadRoomSchedule", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("uses the database contract and returns its schedule", async () => {
+    const schedule: RoomScheduleBlock[] = [
+      {
+        start: "09:00:00",
+        end: "10:00:00",
+        status: "class",
+        details: { type: "class", title: "Algorithms", course: "CS 374" },
+      },
+    ];
+    const rpcCalls: unknown[] = [];
+
+    const result = await loadRoomSchedule(
+      { buildingId: "CIF", roomNumber: "1101", date: "2026-08-24" },
+      {
+        executeRoomScheduleRpc: async (procedure, parameters) => {
+          rpcCalls.push({ procedure, parameters });
+          return { data: schedule, error: null };
+        },
+      },
+    );
+
+    expect(rpcCalls).toEqual([
+      {
+        procedure: "get_room_schedule_cached",
+        parameters: {
+          building_id_param: "CIF",
+          room_number_param: "1101",
+          check_date_param: "2026-08-24",
+        },
+      },
+    ]);
+    expect(result).toEqual(schedule);
+  });
+
+  it("converts database failures into the service error contract", async () => {
+    spyOn(console, "error").mockImplementation(() => {});
+    const databaseError = new Error("connection unavailable");
+
+    const operation = loadRoomSchedule(
+      { buildingId: "CIF", roomNumber: "1101", date: "2026-08-24" },
+      {
+        executeRoomScheduleRpc: async () => ({
+          data: null,
+          error: databaseError,
+        }),
+      },
+    );
+
+    await expect(operation).rejects.toBeInstanceOf(RoomScheduleDatabaseError);
+    await expect(operation).rejects.toMatchObject({ cause: databaseError });
+  });
+});

--- a/src/server/services/room-schedule.test.ts
+++ b/src/server/services/room-schedule.test.ts
@@ -4,6 +4,7 @@ import {
   loadRoomSchedule,
   RoomScheduleDatabaseError,
 } from "./room-schedule";
+import { ExternalResponseError } from "./external-contracts";
 
 describe("loadRoomSchedule", () => {
   afterEach(() => {
@@ -60,5 +61,23 @@ describe("loadRoomSchedule", () => {
 
     await expect(operation).rejects.toBeInstanceOf(RoomScheduleDatabaseError);
     await expect(operation).rejects.toMatchObject({ cause: databaseError });
+  });
+
+  it("rejects malformed schedules at the RPC boundary", async () => {
+    spyOn(console, "error").mockImplementation(() => {});
+
+    const operation = loadRoomSchedule(
+      { buildingId: "CIF", roomNumber: "1101", date: "2026-08-24" },
+      {
+        executeRoomScheduleRpc: async () => ({
+          data: [{ unexpected: true }],
+          error: null,
+        }),
+      },
+    );
+
+    await expect(operation).rejects.toMatchObject({
+      cause: expect.any(ExternalResponseError),
+    });
   });
 });

--- a/src/server/services/room-schedule.ts
+++ b/src/server/services/room-schedule.ts
@@ -10,6 +10,24 @@ export interface RoomScheduleQuery {
   date: string;
 }
 
+export interface RoomScheduleRpcParameters {
+  building_id_param: string;
+  room_number_param: string;
+  check_date_param: string;
+}
+
+export interface RoomScheduleRpcResult {
+  data: unknown;
+  error: unknown;
+}
+
+export interface RoomScheduleServiceDependencies {
+  executeRoomScheduleRpc?: (
+    procedure: "get_room_schedule_cached",
+    parameters: RoomScheduleRpcParameters,
+  ) => Promise<RoomScheduleRpcResult>;
+}
+
 export class RoomScheduleDatabaseError extends Error {
   constructor(options?: ErrorOptions) {
     super("Database error fetching schedule", options);
@@ -17,13 +35,22 @@ export class RoomScheduleDatabaseError extends Error {
   }
 }
 
-export async function loadRoomSchedule({
-  buildingId,
-  roomNumber,
-  date,
-}: RoomScheduleQuery): Promise<RoomScheduleBlock[]> {
+async function executeRoomScheduleRpc(
+  procedure: "get_room_schedule_cached",
+  parameters: RoomScheduleRpcParameters,
+): Promise<RoomScheduleRpcResult> {
   const config = getSupabaseConfig();
   const supabase = createClient(config.url, config.key);
+
+  return await supabase.rpc(procedure, parameters);
+}
+
+export async function loadRoomSchedule(
+  { buildingId, roomNumber, date }: RoomScheduleQuery,
+  dependencies: RoomScheduleServiceDependencies = {},
+): Promise<RoomScheduleBlock[]> {
+  const executeRpc =
+    dependencies.executeRoomScheduleRpc ?? executeRoomScheduleRpc;
 
   const { data, error } = await Sentry.startSpan(
     {
@@ -31,7 +58,7 @@ export async function loadRoomSchedule({
       op: "db.rpc",
     },
     () =>
-      supabase.rpc("get_room_schedule_cached", {
+      executeRpc("get_room_schedule_cached", {
         building_id_param: buildingId,
         room_number_param: roomNumber,
         check_date_param: date,

--- a/src/server/services/room-schedule.ts
+++ b/src/server/services/room-schedule.ts
@@ -3,6 +3,7 @@ import type moment from "moment-timezone";
 import type { RoomScheduleBlock } from "../../types";
 import { getSupabaseConfig } from "../config";
 import { Sentry } from "../observability";
+import { parseRoomSchedule } from "./external-contracts";
 
 export interface RoomScheduleQuery {
   buildingId: string;
@@ -76,7 +77,22 @@ export async function loadRoomSchedule(
     throw new RoomScheduleDatabaseError({ cause: error });
   }
 
-  return Array.isArray(data) ? (data as RoomScheduleBlock[]) : [];
+  try {
+    return parseRoomSchedule(data);
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: {
+        component: "supabase",
+        operation: "get_room_schedule_cached",
+        failure: "invalid-response",
+      },
+    });
+    console.error(
+      `Invalid Supabase schedule response for ${buildingId} - ${roomNumber}:`,
+      error,
+    );
+    throw new RoomScheduleDatabaseError({ cause: error });
+  }
 }
 
 /**

--- a/src/utils/libraryHours.test.ts
+++ b/src/utils/libraryHours.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import moment from "moment-timezone";
+import { isLibraryOpen } from "./libraryHours";
+
+const CAMPUS_TIMEZONE = "America/Chicago";
+
+describe("isLibraryOpen", () => {
+  it("keeps overnight hours open until, but not including, closing time", () => {
+    const atCampusTime = (value: string) =>
+      moment.tz(value, "YYYY-MM-DD HH:mm:ss", CAMPUS_TIMEZONE);
+
+    expect(
+      isLibraryOpen("Funk ACES Library", atCampusTime("2026-08-24 22:30:00")),
+    ).toBe(true);
+    expect(
+      isLibraryOpen("Funk ACES Library", atCampusTime("2026-08-25 01:59:00")),
+    ).toBe(true);
+    expect(
+      isLibraryOpen("Funk ACES Library", atCampusTime("2026-08-25 02:00:00")),
+    ).toBe(false);
+  });
+});

--- a/src/utils/libraryHours.ts
+++ b/src/utils/libraryHours.ts
@@ -41,6 +41,59 @@ export const LIBRARY_HOURS: LibraryHours = {
   },
 };
 
+export interface ActiveLibraryHours {
+  open: moment.Moment;
+  close: moment.Moment;
+}
+
+/**
+ * Resolves the opening interval containing the requested time. Checking the
+ * previous calendar day is necessary for schedules that close after midnight.
+ */
+export const getActiveLibraryHours = (
+  libraryName: string,
+  dateTimeToCheck?: moment.Moment,
+): ActiveLibraryHours | null => {
+  const timezone = "America/Chicago";
+  const targetMoment = (dateTimeToCheck ?? moment()).clone().tz(timezone);
+
+  for (const dayOffset of [0, -1]) {
+    const scheduleDate = targetMoment
+      .clone()
+      .add(dayOffset, "day")
+      .startOf("day");
+    const dayOfWeek = scheduleDate.format("dddd");
+    const hours = LIBRARY_HOURS[libraryName]?.[dayOfWeek];
+    if (!hours) continue;
+
+    const open = moment.tz(
+      `${scheduleDate.format("YYYY-MM-DD")} ${hours.open}`,
+      "YYYY-MM-DD HH:mm",
+      timezone,
+    );
+    const close = moment.tz(
+      `${scheduleDate.format("YYYY-MM-DD")} ${hours.close}`,
+      "YYYY-MM-DD HH:mm",
+      timezone,
+    );
+
+    if (hours.nextDay) {
+      close.add(1, "day");
+    }
+
+    if (
+      open.isValid() &&
+      close.isValid() &&
+      targetMoment.isSameOrAfter(open) &&
+      targetMoment.isBefore(close)
+    ) {
+      return { open, close };
+    }
+  }
+
+  return null;
+};
+
 /**
  * Checks if a library is considered "open" for reservations at a specific date and time.
  * @param libraryName The name of the library.
@@ -50,51 +103,7 @@ export const LIBRARY_HOURS: LibraryHours = {
 export const isLibraryOpen = (
   libraryName: string,
   dateTimeToCheck?: moment.Moment,
-): boolean => {
-  const targetMoment = (dateTimeToCheck || moment()).tz("America/Chicago");
-  const targetTime = targetMoment.format("HH:mm"); // Compare HH:mm
-  const targetDayOfWeek = targetMoment.format("dddd"); // Monday, Tuesday, etc.
-
-  const hours = LIBRARY_HOURS[libraryName]?.[targetDayOfWeek];
-
-  // If no hours defined for this day, it's closed.
-  if (!hours) return false;
-
-  const { open, close, nextDay } = hours;
-
-  // --- Check against the hours for the targetMoment's day ---
-  if (nextDay) {
-    // Scenario 1: Opens today, closes after midnight tomorrow.
-    // Is the target time between today's open time and midnight?
-    if (targetTime >= open) {
-      return true; // Open from open time until midnight
-    }
-    // Note: The case where targetTime is *after* midnight but *before* the close time
-    // will be handled by checking the *previous* day's hours below.
-  } else {
-    // Scenario 2: Opens today, closes today (before midnight).
-    // Is the target time between open and close? (Exclusive of close time)
-    if (targetTime >= open && targetTime < close) {
-      return true;
-    }
-  }
-
-  // --- Check if we are currently within the hours of the *previous* day that extended past midnight ---
-  const previousDayMoment = targetMoment.clone().subtract(1, "day");
-  const previousDayOfWeek = previousDayMoment.format("dddd");
-  const previousHours = LIBRARY_HOURS[libraryName]?.[previousDayOfWeek];
-
-  if (previousHours?.nextDay) {
-    // Scenario 3: Previous day opened and closed after midnight (on the targetMoment's calendar day).
-    // Is the target time *before* the previous day's closing time? (Exclusive of close time)
-    if (targetTime < previousHours.close) {
-      return true;
-    }
-  }
-
-  // If none of the above conditions met, the library is closed at the target time.
-  return false;
-};
+): boolean => getActiveLibraryHours(libraryName, dateTimeToCheck) !== null;
 
 /**
  * Gets a message describing the library's hours for a given day.


### PR DESCRIPTION
Availability now returns only trustworthy partial results. A LibCal failure is isolated to its library and the failed facility is omitted instead of appearing open with a misleading `0/0`; successful libraries and academic data remain available. After-midnight availability also resolves the active prior-day interval, so Funk room durations and slots stop at the correct 2:00 AM closing boundary.

Supabase and LibCal JSON is validated with Zod schemas before domain mapping, with TypeScript payload types inferred from those schemas. Malformed responses follow the existing external-failure path, while mapping runs outside recoverable integration catches so programming defects reach the API error handler. Narrow RPC and HTTP seams provide focused contract coverage without replacing business logic, and the schemas accept the current live Supabase and LibCal payloads. Successful facility response shapes remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of facility availability and room status information.
  - Correctly handles library hours that continue past midnight.
  - Preserves available results when one library’s availability data cannot be retrieved.
  - Prevents malformed external data from producing misleading availability or room-schedule results.
  - Improved error handling for unavailable or invalid room schedules.
- **Reliability**
  - Facility and room-schedule data is now validated before being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Availability processing now validates external contracts, isolates individual LibCal failures, and resolves overnight library intervals against the prior day's schedule.
- Adds Zod schemas for academic availability, LibCal reservations, and room schedules.
- Omits only the affected library when its LibCal request or payload fails.
- Caps overnight room availability at the active interval's closing time.
- Adds injectable RPC and fetch seams with focused contract and overnight-hours tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/services/external-contracts.ts | Introduces centralized Zod validation and normalized errors for all changed external payload boundaries. |
| src/server/services/facilities.ts | Isolates per-library failures, validates RPC and LibCal responses, injects integration seams, and applies active overnight closing times. |
| src/utils/libraryHours.ts | Replaces string-only open checks with concrete current- and prior-day opening intervals. |
| src/server/services/room-schedule.ts | Adds an injectable RPC seam and validates schedules before returning them through the existing service error contract. |
| src/server/services/facilities.test.ts | Covers academic mapping, malformed payloads, LibCal mapping, overnight windows, closing-time caps, and partial failures. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getFacilityStatus] --> B{Requested scope}
    B -->|Academic| C[Supabase availability RPC]
    C --> D[Validate academic payload]
    D -->|Valid| E[Map academic facilities]
    D -->|Invalid or RPC failure| F[Return partial result without academic facilities]
    B -->|Library| G[Resolve active library intervals]
    G --> H[Fetch each open library from LibCal]
    H --> I[Validate reservation payload]
    I -->|Valid| J[Map rooms and cap slots at interval close]
    I -->|Invalid or request failure| K[Omit only failed library]
    E --> L[Merge successful facilities]
    F --> L
    J --> L
    K --> L
```
</details>

<sub>Reviews (3): Last reviewed commit: ["ref(contracts): Replace manual validatio..."](https://github.com/plon/illinispots/commit/0ac2f79ddaa922abadde4432684ded980545561a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55431646)</sub>

<!-- /greptile_comment -->