### PR TITLE
fix(observability): Restore Sentry distributed tracing waterfall in Hono

### DIFF
--- a/src/client/observability.test.ts
+++ b/src/client/observability.test.ts
@@ -40,6 +40,8 @@ function matchesTraceTarget(
 describe("CLIENT_TRACE_PROPAGATION_TARGETS", () => {
   it("matches same-origin, relative, and production domain requests", () => {
     expect(matchesTraceTarget("http://localhost:5173/api/facilities")).toBe(true);
+    expect(matchesTraceTarget("http://localhost/api/facilities")).toBe(true);
+    expect(matchesTraceTarget("http://127.0.0.1:3000/api/facilities")).toBe(true);
     expect(matchesTraceTarget("/api/facilities")).toBe(true);
     expect(matchesTraceTarget("/api/room-schedule")).toBe(true);
     expect(matchesTraceTarget("https://illinispots.com/api/facilities")).toBe(
@@ -49,6 +51,12 @@ describe("CLIENT_TRACE_PROPAGATION_TARGETS", () => {
       matchesTraceTarget("https://www.illinispots.com/api/facilities"),
     ).toBe(true);
     expect(matchesTraceTarget("https://api.mapbox.com/v4/tiles")).toBe(false);
+    expect(
+      matchesTraceTarget("https://api.mapbox.com/search?q=localhost"),
+    ).toBe(false);
+    expect(matchesTraceTarget("https://localhost.attacker.com/api")).toBe(
+      false,
+    );
     expect(
       matchesTraceTarget("https://illinispots.com.attacker.example/api"),
     ).toBe(false);

--- a/src/client/observability.test.ts
+++ b/src/client/observability.test.ts
@@ -28,37 +28,26 @@ describe("resolveClientSentryEnvironment", () => {
   });
 });
 
+function matchesTraceTarget(
+  url: string,
+  targets = CLIENT_TRACE_PROPAGATION_TARGETS,
+): boolean {
+  return targets.some((target) =>
+    typeof target === "string" ? url.includes(target) : target.test(url),
+  );
+}
+
 describe("CLIENT_TRACE_PROPAGATION_TARGETS", () => {
   it("matches same-origin, relative, and production domain requests", () => {
-    const targets = CLIENT_TRACE_PROPAGATION_TARGETS;
-
-    expect(targets).toContain("localhost");
-
-    const relativePattern = targets.find(
-      (target) => target instanceof RegExp && target.source === "^\\/",
+    expect(matchesTraceTarget("http://localhost:5173/api/facilities")).toBe(true);
+    expect(matchesTraceTarget("/api/facilities")).toBe(true);
+    expect(matchesTraceTarget("/api/room-schedule")).toBe(true);
+    expect(matchesTraceTarget("https://illinispots.com/api/facilities")).toBe(
+      true,
     );
-    expect(relativePattern).toBeDefined();
-    expect((relativePattern as RegExp).test("/api/facilities")).toBe(true);
-    expect((relativePattern as RegExp).test("/api/room-schedule")).toBe(true);
-
-    const domainPattern = targets.find(
-      (target) =>
-        target instanceof RegExp &&
-        target.source === "^https:\\/\\/(?:www\\.)?illinispots\\.com",
-    );
-    expect(domainPattern).toBeDefined();
     expect(
-      (domainPattern as RegExp).test(
-        "https://illinispots.com/api/facilities",
-      ),
+      matchesTraceTarget("https://www.illinispots.com/api/facilities"),
     ).toBe(true);
-    expect(
-      (domainPattern as RegExp).test(
-        "https://www.illinispots.com/api/facilities",
-      ),
-    ).toBe(true);
-    expect(
-      (domainPattern as RegExp).test("https://otherdomain.com/api/facilities"),
-    ).toBe(false);
+    expect(matchesTraceTarget("https://api.mapbox.com/v4/tiles")).toBe(false);
   });
 });

--- a/src/client/observability.test.ts
+++ b/src/client/observability.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { resolveClientSentryEnvironment } from "./observability";
+import {
+  CLIENT_TRACE_PROPAGATION_TARGETS,
+  resolveClientSentryEnvironment,
+} from "./observability";
 
 describe("resolveClientSentryEnvironment", () => {
   it("uses the Vercel target so custom environments retain their name", () => {
@@ -22,5 +25,40 @@ describe("resolveClientSentryEnvironment", () => {
     expect(resolveClientSentryEnvironment({ MODE: "development" })).toBe(
       "development",
     );
+  });
+});
+
+describe("CLIENT_TRACE_PROPAGATION_TARGETS", () => {
+  it("matches same-origin, relative, and production domain requests", () => {
+    const targets = CLIENT_TRACE_PROPAGATION_TARGETS;
+
+    expect(targets).toContain("localhost");
+
+    const relativePattern = targets.find(
+      (target) => target instanceof RegExp && target.source === "^\\/",
+    );
+    expect(relativePattern).toBeDefined();
+    expect((relativePattern as RegExp).test("/api/facilities")).toBe(true);
+    expect((relativePattern as RegExp).test("/api/room-schedule")).toBe(true);
+
+    const domainPattern = targets.find(
+      (target) =>
+        target instanceof RegExp &&
+        target.source === "^https:\\/\\/(?:www\\.)?illinispots\\.com",
+    );
+    expect(domainPattern).toBeDefined();
+    expect(
+      (domainPattern as RegExp).test(
+        "https://illinispots.com/api/facilities",
+      ),
+    ).toBe(true);
+    expect(
+      (domainPattern as RegExp).test(
+        "https://www.illinispots.com/api/facilities",
+      ),
+    ).toBe(true);
+    expect(
+      (domainPattern as RegExp).test("https://otherdomain.com/api/facilities"),
+    ).toBe(false);
   });
 });

--- a/src/client/observability.test.ts
+++ b/src/client/observability.test.ts
@@ -49,5 +49,11 @@ describe("CLIENT_TRACE_PROPAGATION_TARGETS", () => {
       matchesTraceTarget("https://www.illinispots.com/api/facilities"),
     ).toBe(true);
     expect(matchesTraceTarget("https://api.mapbox.com/v4/tiles")).toBe(false);
+    expect(
+      matchesTraceTarget("https://illinispots.com.attacker.example/api"),
+    ).toBe(false);
+    expect(
+      matchesTraceTarget("https://www.illinispots.com.attacker.example/api"),
+    ).toBe(false);
   });
 });

--- a/src/client/observability.ts
+++ b/src/client/observability.ts
@@ -17,6 +17,12 @@ export function resolveClientSentryEnvironment(
   );
 }
 
+export const CLIENT_TRACE_PROPAGATION_TARGETS = [
+  "localhost",
+  /^\//,
+  /^https:\/\/(?:www\.)?illinispots\.com/,
+];
+
 export function initializeClientObservability(router: AnyRouter): void {
   if (Sentry.isInitialized()) return;
 
@@ -28,6 +34,7 @@ export function initializeClientObservability(router: AnyRouter): void {
     environment: resolveClientSentryEnvironment(),
     integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
     tracesSampleRate: 1,
+    tracePropagationTargets: CLIENT_TRACE_PROPAGATION_TARGETS,
     sendDefaultPii: false,
   });
 }

--- a/src/client/observability.ts
+++ b/src/client/observability.ts
@@ -18,7 +18,7 @@ export function resolveClientSentryEnvironment(
 }
 
 export const CLIENT_TRACE_PROPAGATION_TARGETS = [
-  "localhost",
+  /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?(?:[/:?#]|$)/,
   /^\//,
   /^https:\/\/(?:www\.)?illinispots\.com(?:[/:?#]|$)/,
 ];

--- a/src/client/observability.ts
+++ b/src/client/observability.ts
@@ -20,7 +20,7 @@ export function resolveClientSentryEnvironment(
 export const CLIENT_TRACE_PROPAGATION_TARGETS = [
   "localhost",
   /^\//,
-  /^https:\/\/(?:www\.)?illinispots\.com/,
+  /^https:\/\/(?:www\.)?illinispots\.com(?:[/:?#]|$)/,
 ];
 
 export function initializeClientObservability(router: AnyRouter): void {

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -135,4 +135,46 @@ describe("server application", () => {
     expect(activeSpanJson).toBeDefined();
     expect(activeSpanJson?.op).toBe("http.server");
   });
+
+  it("isolates request scope tags across concurrent requests", async () => {
+    if (!Sentry.isInitialized()) {
+      Sentry.init({
+        dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+        tracesSampleRate: 1,
+      });
+    }
+
+    let tagAlpha: string | undefined;
+    let tagBeta: string | undefined;
+
+    const testApp = createApp({
+      facilities: {
+        getFacilityStatus: async (_target, scope) => {
+          if (scope === "academic") {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            tagAlpha = Sentry.getIsolationScope().getScopeData().tags
+              .request_id as string;
+          } else {
+            tagBeta = Sentry.getIsolationScope().getScopeData().tags
+              .request_id as string;
+          }
+          return { timestamp: "2026-08-21T14:00:00Z", facilities: {} };
+        },
+      },
+    });
+
+    const [resAlpha, resBeta] = await Promise.all([
+      testApp.request("/api/facilities?type=academic", {
+        headers: { "x-request-id": "req-alpha" },
+      }),
+      testApp.request("/api/facilities?type=library", {
+        headers: { "x-request-id": "req-beta" },
+      }),
+    ]);
+
+    expect(resAlpha.status).toBe(200);
+    expect(resBeta.status).toBe(200);
+    expect(tagAlpha).toBe("req-alpha");
+    expect(tagBeta).toBe("req-beta");
+  });
 });

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -108,4 +108,31 @@ describe("server application", () => {
     expect(response.status).toBe(200);
     expect(activeSpanInsideHandler).toBeUndefined();
   });
+
+  it("records HTTP status on server span when a route throws", async () => {
+    if (!Sentry.isInitialized()) {
+      Sentry.init({
+        dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+        tracesSampleRate: 1,
+      });
+    }
+
+    let activeSpanJson: ReturnType<typeof Sentry.spanToJSON> | undefined;
+    const testApp = createApp({
+      facilities: {
+        getFacilityStatus: async () => {
+          const activeSpan = Sentry.getActiveSpan();
+          if (activeSpan) {
+            activeSpanJson = Sentry.spanToJSON(activeSpan);
+          }
+          throw new Error("Simulated facility failure");
+        },
+      },
+    });
+
+    const response = await testApp.request("/api/facilities");
+    expect(response.status).toBe(500);
+    expect(activeSpanJson).toBeDefined();
+    expect(activeSpanJson?.op).toBe("http.server");
+  });
 });

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { createApp } from "./app";
+import { Sentry } from "./observability";
 
 describe("server application", () => {
   it("reports runtime health", async () => {
@@ -45,5 +46,46 @@ describe("server application", () => {
     expect(response.headers.get("location")).toBe(
       "https://illinispots.com/path?x=1",
     );
+  });
+
+  it("propagates incoming distributed tracing headers into server spans", async () => {
+    if (!Sentry.isInitialized()) {
+      Sentry.init({
+        dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+        tracesSampleRate: 1,
+      });
+    }
+
+    let capturedTraceId: string | undefined;
+    let capturedParentSpanId: string | undefined;
+    let capturedSpanName: string | undefined;
+
+    const testApp = createApp({
+      facilities: {
+        getFacilityStatus: async () => {
+          const activeSpan = Sentry.getActiveSpan();
+          if (activeSpan) {
+            const spanJson = Sentry.spanToJSON(activeSpan);
+            capturedTraceId = spanJson.trace_id;
+            capturedParentSpanId = spanJson.parent_span_id;
+            capturedSpanName = spanJson.description;
+          }
+          return { timestamp: "2026-08-21T14:00:00Z", facilities: {} };
+        },
+      },
+    });
+
+    const sentryTrace = "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1";
+    const response = await testApp.request("/api/facilities", {
+      headers: {
+        "sentry-trace": sentryTrace,
+        baggage: "sentry-environment=production",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedTraceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+    expect(capturedParentSpanId).toBe("00f067aa0ba902b7");
+    expect(capturedSpanName).toBe("GET /api/facilities");
   });
 });

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -88,4 +88,24 @@ describe("server application", () => {
     expect(capturedParentSpanId).toBe("00f067aa0ba902b7");
     expect(capturedSpanName).toBe("GET /api/facilities");
   });
+
+  it("skips span creation for static assets under /assets/", async () => {
+    if (!Sentry.isInitialized()) {
+      Sentry.init({
+        dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+        tracesSampleRate: 1,
+      });
+    }
+
+    let activeSpanInsideHandler: unknown = "unreached";
+    const customApp = createApp();
+    customApp.get("/assets/custom-asset.js", (context) => {
+      activeSpanInsideHandler = Sentry.getActiveSpan();
+      return context.text("asset");
+    });
+
+    const response = await customApp.request("/assets/custom-asset.js");
+    expect(response.status).toBe(200);
+    expect(activeSpanInsideHandler).toBeUndefined();
+  });
 });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -13,7 +13,7 @@ import {
   createRoomScheduleRoutes,
   type RoomScheduleRouteDependencies,
 } from "./routes/room-schedule";
-import { Sentry } from "./observability";
+import { Sentry, sentryTracing } from "./observability";
 
 export interface AppDependencies {
   clientConfig?: ClientConfig;
@@ -27,37 +27,7 @@ export function createApp(dependencies: AppDependencies = {}) {
   const isTest = process.env.NODE_ENV === "test";
 
   app.use("*", requestId());
-  app.use("*", async (context, next) => {
-    const sentryTrace = context.req.header("sentry-trace");
-    const baggage = context.req.header("baggage");
-
-    return Sentry.continueTrace({ sentryTrace, baggage }, () => {
-      return Sentry.startSpan(
-        {
-          name: `${context.req.method} ${context.req.path}`,
-          op: "http.server",
-          attributes: {
-            "http.method": context.req.method,
-            "http.url": context.req.url,
-            "http.route": context.req.path,
-          },
-        },
-        async (span) => {
-          const reqId = context.get("requestId");
-          if (reqId && typeof reqId === "string") {
-            span?.setAttribute("http.request_id", reqId);
-            Sentry.setTag("request_id", reqId);
-          }
-
-          await next();
-
-          if (span) {
-            Sentry.setHttpStatus(span, context.res.status);
-          }
-        },
-      );
-    });
-  });
+  app.use("*", sentryTracing());
   app.use("*", secureHeaders());
 
   if (!isTest) {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -27,6 +27,37 @@ export function createApp(dependencies: AppDependencies = {}) {
   const isTest = process.env.NODE_ENV === "test";
 
   app.use("*", requestId());
+  app.use("*", async (context, next) => {
+    const sentryTrace = context.req.header("sentry-trace");
+    const baggage = context.req.header("baggage");
+
+    return Sentry.continueTrace({ sentryTrace, baggage }, () => {
+      return Sentry.startSpan(
+        {
+          name: `${context.req.method} ${context.req.path}`,
+          op: "http.server",
+          attributes: {
+            "http.method": context.req.method,
+            "http.url": context.req.url,
+            "http.route": context.req.path,
+          },
+        },
+        async (span) => {
+          const reqId = context.get("requestId");
+          if (reqId && typeof reqId === "string") {
+            span?.setAttribute("http.request_id", reqId);
+            Sentry.setTag("request_id", reqId);
+          }
+
+          await next();
+
+          if (span) {
+            Sentry.setHttpStatus(span, context.res.status);
+          }
+        },
+      );
+    });
+  });
   app.use("*", secureHeaders());
 
   if (!isTest) {

--- a/src/server/observability.ts
+++ b/src/server/observability.ts
@@ -22,33 +22,40 @@ export function sentryTracing(): MiddlewareHandler {
     const sentryTrace = context.req.header("sentry-trace");
     const baggage = context.req.header("baggage");
 
-    return Sentry.continueTrace({ sentryTrace, baggage }, () => {
-      return Sentry.startSpan(
-        {
-          name: `${context.req.method} ${context.req.path}`,
-          op: "http.server",
-          attributes: {
-            "http.method": context.req.method,
-            "http.url": context.req.url,
-            "http.route": context.req.path,
+    return Sentry.withIsolationScope(() => {
+      return Sentry.continueTrace({ sentryTrace, baggage }, () => {
+        return Sentry.startSpan(
+          {
+            name: `${context.req.method} ${context.req.path}`,
+            op: "http.server",
+            attributes: {
+              "http.method": context.req.method,
+              "http.url": context.req.url,
+              "http.route": context.req.path,
+            },
           },
-        },
-        async (span) => {
-          const reqId = context.get("requestId");
-          if (reqId && typeof reqId === "string") {
-            span?.setAttribute("http.request_id", reqId);
-            Sentry.setTag("request_id", reqId);
-          }
-
-          try {
-            await next();
-          } finally {
-            if (span) {
-              Sentry.setHttpStatus(span, context.res.status);
+          async (span) => {
+            const reqId = context.get("requestId");
+            if (reqId && typeof reqId === "string") {
+              span?.setAttribute("http.request_id", reqId);
+              Sentry.setTag("request_id", reqId);
             }
-          }
-        },
-      );
+
+            try {
+              await next();
+            } catch (error) {
+              if (span) {
+                Sentry.setHttpStatus(span, 500);
+              }
+              throw error;
+            } finally {
+              if (span && context.finalized) {
+                Sentry.setHttpStatus(span, context.res.status);
+              }
+            }
+          },
+        );
+      });
     });
   };
 }

--- a/src/server/observability.ts
+++ b/src/server/observability.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/bun";
+import type { MiddlewareHandler } from "hono";
 import { getServerConfig } from "./config";
 
 const config = getServerConfig();
@@ -10,6 +11,46 @@ if (config.sentryDsn) {
     tracesSampleRate: 1,
     sendDefaultPii: false,
   });
+}
+
+export function sentryTracing(): MiddlewareHandler {
+  return async (context, next) => {
+    if (context.req.path.startsWith("/assets/")) {
+      return await next();
+    }
+
+    const sentryTrace = context.req.header("sentry-trace");
+    const baggage = context.req.header("baggage");
+
+    return Sentry.continueTrace({ sentryTrace, baggage }, () => {
+      return Sentry.startSpan(
+        {
+          name: `${context.req.method} ${context.req.path}`,
+          op: "http.server",
+          attributes: {
+            "http.method": context.req.method,
+            "http.url": context.req.url,
+            "http.route": context.req.path,
+          },
+        },
+        async (span) => {
+          const reqId = context.get("requestId");
+          if (reqId && typeof reqId === "string") {
+            span?.setAttribute("http.request_id", reqId);
+            Sentry.setTag("request_id", reqId);
+          }
+
+          try {
+            await next();
+          } finally {
+            if (span) {
+              Sentry.setHttpStatus(span, context.res.status);
+            }
+          }
+        },
+      );
+    });
+  };
 }
 
 export { Sentry };


### PR DESCRIPTION
## Summary

When migrating from Next.js (`@sentry/nextjs`) to Vite + Hono, automatic distributed trace propagation and server-side request transactions were lost because Hono does not auto-wrap incoming requests or continue trace headers out-of-the-box.

This PR restores the end-to-end distributed tracing waterfall:
1. **Server Trace Continuation & Spans**: Adds middleware in [`src/server/app.ts`](file:///home/ubuntu/code/illinispots/src/server/app.ts) using `Sentry.continueTrace` to extract incoming `sentry-trace` and `baggage` headers and wrap request handling in an `http.server` span.
2. **Request Context**: Associates the `requestId` with the span attributes and Sentry scope tags.
3. **HTTP Status Reporting**: Automatically attaches the response HTTP status code to the Sentry server span using `Sentry.setHttpStatus`.
4. **Client Trace Propagation**: Explicitly configures `tracePropagationTargets` in [`src/client/observability.ts`](file:///home/ubuntu/code/illinispots/src/client/observability.ts) to match localhost, relative paths, and `illinispots.com`.
5. **Tests**: Adds unit tests verifying distributed tracing header extraction and trace ID/parent span linkage in [`src/server/app.test.ts`](file:///home/ubuntu/code/illinispots/src/server/app.test.ts) and target regex validation in [`src/client/observability.test.ts`](file:///home/ubuntu/code/illinispots/src/client/observability.test.ts).

## Verification
- All 29 unit tests pass (`bun test`)
- Linting and build typechecking succeed (`bun run check`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end request tracing across client and server interactions.
  * Preserved trace context across supported local, relative, and production URLs.
  * Server-side spans now capture request details, request IDs, and response status.
  * Incoming tracing information is continued for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores distributed tracing across browser and Hono request boundaries and completes the fixes requested in the prior review.
- Adds isolated server request spans that continue incoming Sentry trace context.
- Records request IDs and final HTTP status information on server spans.
- Restricts browser trace propagation to local, relative, and IlliniSpots URLs.
- Adds coverage for trace continuation, asset exclusion, concurrent request isolation, thrown requests, and propagation-target boundaries.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/observability.ts | Adds request-scoped trace continuation, server spans, request ID tagging, asset exclusion, and success/error HTTP status recording. |
| src/server/app.ts | Installs the tracing middleware after request ID generation so request metadata is available to each server span. |
| src/server/app.test.ts | Adds coverage for continued trace identity, static-asset exclusion, thrown requests, and concurrent scope isolation. |
| src/client/observability.ts | Configures trace propagation targets with explicit hostname boundaries for local and production origins. |
| src/client/observability.test.ts | Verifies accepted application URLs and rejects unrelated hosts with misleading hostname prefixes. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant Hono
    participant Sentry
    participant Route
    Browser->>Hono: Request with sentry-trace and baggage
    Hono->>Sentry: Create isolated scope and continue trace
    Sentry->>Sentry: Start http.server span
    Sentry->>Route: Run request handler
    Route-->>Sentry: Response or thrown error
    Sentry->>Sentry: Record HTTP status and finish span
    Sentry-->>Hono: Complete middleware
    Hono-->>Browser: HTTP response
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(observability): Isolate request scop..."](https://github.com/plon/illinispots/commit/15d2e0c9d35e12ede27fbc575e172a05d0ae9d99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55575781)</sub>

<!-- /greptile_comment -->