### PR TITLE
fix(ui): Prevent layout shifts in facility list skeletons

### DIFF
--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -115,19 +115,21 @@ const IlliniSpotsPage: React.FC = () => {
   });
 
   const facilityData = useMemo<FacilityStatus | undefined>(() => {
-    if (!academicData) {
+    if (!academicData && !libraryData) {
       return undefined;
     }
 
     const matchingLibraryFacilities =
-      libraryData?.timestamp === academicData.timestamp
-        ? libraryData.facilities
+      !academicData ||
+      !libraryData ||
+      libraryData.timestamp === academicData.timestamp
+        ? libraryData?.facilities || {}
         : {};
 
     return {
-      timestamp: academicData.timestamp,
+      timestamp: academicData?.timestamp || libraryData?.timestamp || "",
       facilities: {
-        ...academicData.facilities,
+        ...(academicData?.facilities || {}),
         ...matchingLibraryFacilities,
       },
     };

--- a/src/components/FacilityAccordion.tsx
+++ b/src/components/FacilityAccordion.tsx
@@ -100,7 +100,7 @@ export const FacilityAccordion: React.FC<FacilityAccordionProps> = ({
         >
           <div className="flex items-center justify-between flex-1 mr-2">
             <div className="flex items-center gap-2 min-w-0 flex-1">
-              <span className="font-medium">{facility.name}</span>
+              <span className="font-medium truncate">{facility.name}</span>
             </div>
             <div className="flex items-center gap-1 ml-2">
               {!facility.isOpen ? (

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -402,13 +402,13 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                                 <div
                                                     className={`h-4 rounded bg-muted animate-pulse ${
                                                         index === 0
-                                                            ? "w-44"
+                                                            ? "w-36"
                                                             : index === 1
-                                                              ? "w-32"
-                                                              : "w-28"
+                                                              ? "w-52"
+                                                              : "w-24"
                                                     }`}
                                                 />
-                                                <div className="flex items-center gap-3">
+                                                <div className="flex items-center gap-2">
                                                     <div className="h-[22px] w-12 rounded-full bg-muted animate-pulse" />
                                                     <div className="h-4 w-4 rounded bg-muted animate-pulse" />
                                                 </div>
@@ -452,19 +452,21 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                 </h2>
                                 <span className="sr-only">Loading academic availability…</span>
                                 <div aria-hidden="true">
-                                    {[0, 1, 2, 3, 4, 5].map((index) => (
+                                    {Array.from({ length: 20 }, (_, index) => (
                                         <div key={index} className="border-b">
                                             <div className="h-[38px] px-4 flex items-center justify-between">
                                                 <div
                                                     className={`h-4 rounded bg-muted animate-pulse ${
-                                                        index % 3 === 0
+                                                        index % 4 === 0
                                                             ? "w-44"
-                                                            : index % 3 === 1
+                                                            : index % 4 === 1
                                                               ? "w-36"
-                                                              : "w-52"
+                                                              : index % 4 === 2
+                                                                ? "w-52"
+                                                                : "w-28"
                                                     }`}
                                                 />
-                                                <div className="flex items-center gap-3">
+                                                <div className="flex items-center gap-2">
                                                     <div className="h-[22px] w-12 rounded-full bg-muted animate-pulse" />
                                                     <div className="h-4 w-4 rounded bg-muted animate-pulse" />
                                                 </div>


### PR DESCRIPTION
Resolves Cumulative Layout Shift (CLS) issues in the facility list skeletons and sidebar loading flow:

- **Asynchronous facility data merge:** `facilityData` now merges query results as each dataset resolves rather than gating on `academicData`. When the faster library query completes, library items render immediately instead of unmounting the skeleton, collapsing to 0 height, and popping back in after academic data finishes.
- **Accurate skeleton dimensions:** Library skeleton placeholder bar widths now align with the 3 static libraries in alphabetical order, and badge-to-chevron spacing is adjusted from `gap-3` (12px) to `gap-2` (8px) to match the accordion trigger layout.
- **Single-line row height stability:** Added `truncate` to `FacilityAccordion` titles so long building names on mobile viewports ($\le 390\text{px}$) no longer wrap onto multiple lines and expand row height from 39px to 57px.
- **Full viewport skeleton coverage:** Increased the academic skeleton placeholder count to 20 items so the sidebar is visually populated on tall screens during initial load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Facility information now displays correctly when only library data is available.
  * Facility data safely falls back when no source data is available.
  * Long facility names are truncated to prevent layout overflow.

* **UI Improvements**
  * Updated loading placeholders for library and academic facility lists.
  * Expanded academic loading states with more rows and varied placeholder widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces loading-time layout shifts in the facility sidebar.
- Allows library results to render before academic results while retaining timestamp-safe merging.
- Aligns skeleton dimensions and spacing with loaded accordion rows.
- Keeps facility titles on one line and expands academic skeleton viewport coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The asynchronous merge remains timestamp-aware, visual truncation preserves the full accessible text, and the expanded skeleton remains contained by the sidebar scroll area.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/client/routes/index.tsx | Updates the memoized facility merge to render whichever dataset resolves first while merging both when their timestamps agree. |
| src/components/FacilityAccordion.tsx | Visually truncates long facility names without changing their underlying text or accessible name. |
| src/components/left.tsx | Adjusts skeleton widths and spacing and increases academic placeholders within the sidebar's internal scroll area. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): Prevent layout shifts in facili..."](https://github.com/plon/illinispots/commit/282a86f01b53d3ab5a1737926d58f16e85313174) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55778061)</sub>

<!-- /greptile_comment -->