### PR TITLE
fix(map): Prevent non-fatal Mapbox errors from blocking mobile map load

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="index, follow" />
     <meta
       name="description"

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -1,3 +1,4 @@
+@import "mapbox-gl/dist/mapbox-gl.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -195,16 +195,32 @@ export default function FacilityMap({
         setMapError(null);
         setIsMapLoaded(true);
 
-        // Hide/show POI labels depending on zoom level using Mapbox Standard basemap config
+        // Configure Mapbox Standard basemap lighting and labels
         const POI_MIN_VISIBLE_ZOOM = 17; // Hide POI labels below this zoom
 
-        const applyPoiVisibility = () => {
-          const show = mapInstance.getZoom() >= POI_MIN_VISIBLE_ZOOM;
+        const applyBasemapConfig = () => {
+          const isDark =
+            typeof window !== "undefined" &&
+            (document.documentElement.classList.contains("dark") ||
+              Boolean(window.matchMedia?.("(prefers-color-scheme: dark)")?.matches));
+
+          const showPoi = mapInstance.getZoom() >= POI_MIN_VISIBLE_ZOOM;
+
           try {
             mapInstance.setConfigProperty(
               "basemap",
+              "lightPreset",
+              isDark ? "dusk" : "day",
+            );
+            mapInstance.setConfigProperty(
+              "basemap",
+              "showRoadLabels",
+              true,
+            );
+            mapInstance.setConfigProperty(
+              "basemap",
               "showPointOfInterestLabels",
-              show,
+              showPoi,
             );
           } catch {
             // Non-standard style or config not supported
@@ -212,8 +228,8 @@ export default function FacilityMap({
         };
 
         // Initialize and bind to zoom updates
-        applyPoiVisibility();
-        mapInstance.on("zoom", applyPoiVisibility);
+        applyBasemapConfig();
+        mapInstance.on("zoom", applyBasemapConfig);
       };
 
       mapInstance.on("style.load", onMapReady);

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -176,7 +176,8 @@ export default function FacilityMap({
           }
         }
       });
-      mapInstance.on("load", () => {
+      const onMapReady = () => {
+        if (hasLoaded) return;
         hasLoaded = true;
         recordMapOutcome("success");
         if (trackInitialLoadRef.current && !mapReadyRecorded.current) {
@@ -205,8 +206,15 @@ export default function FacilityMap({
         // Initialize and bind to zoom updates
         applyPoiVisibility();
         mapInstance.on("zoom", applyPoiVisibility);
-      });
+      };
 
+      mapInstance.on("style.load", onMapReady);
+      mapInstance.on("load", onMapReady);
+      mapInstance.on("idle", onMapReady);
+
+      if (mapInstance.isStyleLoaded()) {
+        onMapReady();
+      }
       mapInstance.addControl(new mapboxgl.NavigationControl());
       mapInstance.addControl(
         new mapboxgl.GeolocateControl({

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -14,6 +14,7 @@ import {
   type MapLoadResult,
 } from "@/utils/loadingMetrics";
 import { getClientConfig } from "@/client/config";
+import { Sentry } from "@/client/observability";
 export default function FacilityMap({
   facilityData,
   onMarkerClick,
@@ -35,6 +36,7 @@ export default function FacilityMap({
   const mapReadyRecorded = useRef(false);
   const [isMapLoaded, setIsMapLoaded] = useState(false);
   const [mapError, setMapError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     trackInitialLoadRef.current = trackInitialLoad;
@@ -43,6 +45,8 @@ export default function FacilityMap({
   useEffect(() => {
     if (!mapContainer.current) return;
 
+    mapLoadOutcomeRecorded.current = false;
+    mapReadyRecorded.current = false;
     const mapLoadStartedAt = performance.now();
     const recordMapOutcome = (result: MapLoadResult) => {
       if (mapLoadOutcomeRecorded.current) return;
@@ -58,6 +62,19 @@ export default function FacilityMap({
     setIsMapLoaded(false);
     setMapError(null);
 
+    if (!mapboxgl.supported()) {
+      console.error("Mapbox GL is not supported by this browser or device.");
+      recordMapOutcome("initialization_error");
+      Sentry.captureMessage("WebGL is not supported on this device or browser", {
+        level: "error",
+        tags: { component: "map", outcome: "initialization_error" },
+      });
+      setMapError(
+        "Your browser or device does not support WebGL, which is required to load the map.",
+      );
+      return;
+    }
+
     const config = getClientConfig();
     const styleUrl = config.mapboxStyleUrl;
     const token = config.mapboxAccessToken;
@@ -66,10 +83,13 @@ export default function FacilityMap({
         "Mapbox style and access token are not configured.",
       );
       recordMapOutcome("missing_configuration");
+      Sentry.captureMessage("Mapbox style or access token is not configured", {
+        level: "error",
+        tags: { component: "map", outcome: "missing_configuration" },
+      });
       setMapError("The map is not configured.");
       return;
     }
-
     mapboxgl.accessToken = token;
 
     try {
@@ -84,13 +104,64 @@ export default function FacilityMap({
       map.current = mapInstance;
 
       mapInstance.on("error", (event) => {
-        console.error("Mapbox failed to load:", event.error);
-        if (!hasLoaded) {
+        const err: unknown = event?.error;
+        console.warn("Mapbox error event:", err);
+
+        // Distinguish fatal style/auth errors from non-fatal resource errors
+        // (e.g. telemetry blocked by Safari Content Blockers, missing glyphs, tile 404s).
+        let status: number | undefined;
+        let message = "";
+        let sourceId: string | undefined;
+
+        if (err && typeof err === "object") {
+          if ("status" in err && typeof err.status === "number") {
+            status = err.status;
+          }
+          if ("message" in err && typeof err.message === "string") {
+            message = err.message.toLowerCase();
+          }
+          if ("sourceId" in err && typeof err.sourceId === "string") {
+            sourceId = err.sourceId;
+          }
+        } else if (typeof err === "string") {
+          message = err.toLowerCase();
+        }
+
+        const isAuthError =
+          status === 401 ||
+          status === 403 ||
+          message.includes("forbidden") ||
+          message.includes("unauthorized") ||
+          message.includes("not allowed to use this token");
+
+        const isFatalStyleError =
+          !hasLoaded &&
+          (status === 404 || message.includes("style")) &&
+          !sourceId;
+
+        if (!hasLoaded && (isAuthError || isFatalStyleError)) {
           recordMapOutcome("load_error");
-          setMapError("The map could not be loaded.");
+          const errMessage =
+            message || (isAuthError ? "Mapbox authorization error" : "Mapbox style load error");
+          const errorObject =
+            err instanceof Error ? err : new Error(errMessage);
+          Sentry.captureException(errorObject, {
+            tags: {
+              component: "map",
+              outcome: "load_error",
+              error_type: isAuthError ? "auth" : "style",
+            },
+            extra: { status, message, isAuthError, isFatalStyleError },
+          });
+          if (isAuthError) {
+            setMapError(
+              "The map could not be loaded due to a Mapbox token authorization error. If accessing from a local network IP on mobile, ensure your token allows this URL/domain in Mapbox settings.",
+            );
+          } else {
+            setMapError("The map could not be loaded.");
+          }
         }
       });
-
       mapInstance.on("load", () => {
         hasLoaded = true;
         recordMapOutcome("success");
@@ -132,16 +203,18 @@ export default function FacilityMap({
     } catch (error) {
       console.error("Mapbox initialization failed:", error);
       recordMapOutcome("initialization_error");
+      Sentry.captureException(error, {
+        tags: { component: "map", outcome: "initialization_error" },
+      });
       setMapError("The map could not be loaded.");
     }
-
     return () => {
       if (map.current) {
         map.current.remove();
         map.current = null;
       }
     };
-  }, []);
+  }, [retryCount]);
 
   useEffect(() => {
     if (!map.current || !isMapLoaded || !facilityData) return;
@@ -493,9 +566,19 @@ export default function FacilityMap({
           className="absolute inset-0 z-10 flex items-center justify-center bg-background p-6 text-center"
           role="alert"
         >
-          <div>
+          <div className="max-w-md space-y-3">
             <p className="font-medium">Map unavailable</p>
-            <p className="mt-1 text-sm text-muted-foreground">{mapError}</p>
+            <p className="text-sm text-muted-foreground">{mapError}</p>
+            <button
+              type="button"
+              onClick={() => {
+                setMapError(null);
+                setRetryCount((c) => c + 1);
+              }}
+              className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Try again
+            </button>
           </div>
         </div>
       )}

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -97,7 +97,6 @@ export default function FacilityMap({
         container: mapContainer.current,
         style: styleUrl,
         trackResize: true,
-        antialias: true,
       });
       let hasLoaded = false;
 

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -107,13 +107,18 @@ export default function FacilityMap({
         const err: unknown = event?.error;
         console.warn("Mapbox error event:", err);
 
-        // Distinguish fatal style/auth errors from non-fatal resource errors
-        // (e.g. telemetry blocked by Safari Content Blockers, missing glyphs, tile 404s).
+        // Subresource issues (e.g. telemetry blocked by Safari Content Blockers,
+        // missing font glyphs, sprite icons, individual 3D models, or tile 404s)
+        // are non-fatal. Mapbox GL continues rendering the basemap and markers.
         let status: number | undefined;
         let message = "";
         let sourceId: string | undefined;
+        let url = "";
 
         if (err && typeof err === "object") {
+          if ("url" in err && typeof err.url === "string") {
+            url = err.url;
+          }
           if ("status" in err && typeof err.status === "number") {
             status = err.status;
           }
@@ -127,35 +132,44 @@ export default function FacilityMap({
           message = err.toLowerCase();
         }
 
-        const isAuthError =
-          status === 401 ||
-          status === 403 ||
-          message.includes("forbidden") ||
-          message.includes("unauthorized") ||
-          message.includes("not allowed to use this token");
+        // Telemetry pings or subresource assets (tiles, glyphs, sprites, models)
+        // must never abort the map.
+        const isTelemetryOrSubresource =
+          url.includes("events.mapbox.com") ||
+          url.includes("/fonts/") ||
+          url.includes("/sprites/") ||
+          url.includes("/models/") ||
+          url.includes("/v4/") ||
+          Boolean(sourceId);
 
-        const isFatalStyleError =
-          !hasLoaded &&
-          (status === 404 || message.includes("style")) &&
-          !sourceId;
+        if (isTelemetryOrSubresource) {
+          return;
+        }
 
-        if (!hasLoaded && (isAuthError || isFatalStyleError)) {
+        const isRootStyleAuthError =
+          (status === 401 || status === 403) &&
+          (url.includes("/styles/") || message.includes("forbidden") || message.includes("unauthorized"));
+
+        const isRootStyleNotFound =
+          status === 404 && url.includes("/styles/");
+
+        if (!hasLoaded && (isRootStyleAuthError || isRootStyleNotFound)) {
           recordMapOutcome("load_error");
           const errMessage =
-            message || (isAuthError ? "Mapbox authorization error" : "Mapbox style load error");
+            message || (isRootStyleAuthError ? "Mapbox authorization error" : "Mapbox style load error");
           const errorObject =
             err instanceof Error ? err : new Error(errMessage);
           Sentry.captureException(errorObject, {
             tags: {
               component: "map",
               outcome: "load_error",
-              error_type: isAuthError ? "auth" : "style",
+              error_type: isRootStyleAuthError ? "auth" : "style",
             },
-            extra: { status, message, isAuthError, isFatalStyleError },
+            extra: { status, message, url, isRootStyleAuthError, isRootStyleNotFound },
           });
-          if (isAuthError) {
+          if (isRootStyleAuthError) {
             setMapError(
-              "The map could not be loaded due to a Mapbox token authorization error. If accessing from a local network IP on mobile, ensure your token allows this URL/domain in Mapbox settings.",
+              "The map could not be loaded due to a Mapbox token authorization error. Please check your Mapbox access token and allowed URLs.",
             );
           } else {
             setMapError("The map could not be loaded.");

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -96,7 +96,7 @@ export default function FacilityMap({
       const mapInstance = new mapboxgl.Map({
         container: mapContainer.current,
         style: styleUrl,
-        // minZoom: 15.2,
+        trackResize: true,
         antialias: true,
       });
       let hasLoaded = false;
@@ -179,6 +179,15 @@ export default function FacilityMap({
       const onMapReady = () => {
         if (hasLoaded) return;
         hasLoaded = true;
+
+        mapInstance.resize();
+        requestAnimationFrame(() => {
+          mapInstance.resize();
+        });
+        setTimeout(() => {
+          mapInstance.resize();
+        }, 100);
+
         recordMapOutcome("success");
         if (trackInitialLoadRef.current && !mapReadyRecorded.current) {
           mapReadyRecorded.current = true;
@@ -222,6 +231,21 @@ export default function FacilityMap({
           trackUserLocation: true,
         }),
       );
+      let resizeObserver: ResizeObserver | null = null;
+      if (typeof ResizeObserver !== "undefined" && mapContainer.current) {
+        resizeObserver = new ResizeObserver(() => {
+          map.current?.resize();
+        });
+        resizeObserver.observe(mapContainer.current);
+      }
+
+      return () => {
+        resizeObserver?.disconnect();
+        if (map.current) {
+          map.current.remove();
+          map.current = null;
+        }
+      };
     } catch (error) {
       console.error("Mapbox initialization failed:", error);
       recordMapOutcome("initialization_error");
@@ -230,16 +254,12 @@ export default function FacilityMap({
       });
       setMapError("The map could not be loaded.");
     }
-    return () => {
-      if (map.current) {
-        map.current.remove();
-        map.current = null;
-      }
-    };
   }, [retryCount]);
 
   useEffect(() => {
     if (!map.current || !isMapLoaded || !facilityData) return;
+
+    map.current.resize();
 
     if (activePopupRef.current) {
       activePopupRef.current.remove();

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -11,7 +11,7 @@ import {
   createRoomScheduleRoutes,
   type RoomScheduleRouteDependencies,
 } from "./routes/room-schedule";
-import { sentryRequestContext, sentryTracing } from "./observability";
+import { Sentry, sentryRequestContext, sentryTracing } from "./observability";
 import { getPublicClientConfig } from "./config";
 import { injectClientConfig, loadIndexHtml } from "./html";
 
@@ -174,6 +174,7 @@ export function createApp(dependencies: AppDependencies = {}) {
   );
 
   app.onError((error, context) => {
+    Sentry.captureException(error);
     console.error("Unhandled server error:", error);
     return context.json({ error: "Internal server error" }, 500);
   });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -31,7 +31,12 @@ export function createApp(dependencies: AppDependencies = {}) {
   app.use(sentryTracing(app));
   app.use("*", requestId());
   app.use("*", sentryRequestContext());
-  app.use("*", secureHeaders());
+  app.use(
+    "*",
+    secureHeaders({
+      referrerPolicy: "strict-origin-when-cross-origin",
+    }),
+  );
 
   if (!isTest) {
     app.use("*", logger());


### PR DESCRIPTION
Mapbox GL JS emits error events for subresource requests such as blocked telemetry calls to `events.mapbox.com`, missing font glyphs, and 404 tile requests. On mobile Safari, iOS Advanced Tracking and Fingerprinting Protection and content blockers block telemetry pings during initialization. Because any error event received before `map.on("load")` was treated as fatal, the full-screen "Map unavailable" overlay replaced the map even when the map rendered normally.

This change:
- Filters non-fatal background errors from actual fatal failures (HTTP 401/403 authorization failures and root style loading errors).
- Adds a WebGL support check via `mapboxgl.supported()` before initializing Mapbox.
- Reports fatal map initialization and loading failures directly to Sentry issues with component tags and diagnostic details.
- Forwards unhandled server route exceptions to Sentry in the Hono error handler.
- Adds an interactive "Try again" action to the error overlay so users can retry map initialization without a full page refresh.














<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR distinguishes fatal Mapbox style failures from recoverable subresource errors and adds retry, compatibility checking, and Sentry reporting.
- Adds WebGL capability validation and detailed Mapbox load-error classification.
- Adds a user-facing map retry action and map resize handling.
- Reports unhandled server exceptions to Sentry.
- Updates viewport, Mapbox CSS, and referrer-policy configuration.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because retrying a failed map can produce a replacement map without unchanged facility markers.

The retry cleanup removes the old Mapbox instance without clearing its marker cache, and subsequent reconciliation skips recreating unchanged cached markers on the new map.

**Files Needing Attention:** src/components/map.tsx

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/map.tsx | Adds recoverable Mapbox error handling, WebGL validation, Sentry diagnostics, and retry behavior; the previously reported stale-marker retry defect remains. |
| src/server/app.ts | Adds Sentry capture for unhandled server errors and configures a stricter referrer policy. |
| src/client/styles.css | Imports Mapbox GL styles through the global stylesheet. |
| index.html | Restores a zoomable mobile viewport configuration. |

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(server): Configure strict-origin-whe..."](https://github.com/plon/illinispots/commit/319941772474e5c3587b89620bf0dd4d9404a457) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55780312)</sub>

<!-- /greptile_comment -->