### PR TITLE
fix(map): Fix mobile map loading and add timeout fallback

### DIFF
--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -84,8 +84,31 @@ export default function FacilityMap({
       map.current = mapInstance;
 
       mapInstance.on("error", (event) => {
-        console.error("Mapbox failed to load:", event.error);
-        if (!hasLoaded) {
+        console.error("Mapbox error:", event.error);
+        if (hasLoaded) return;
+
+        const error = event.error;
+        let status: unknown;
+        if (error && typeof error === "object" && "status" in error) {
+          status = error.status;
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : typeof error === "string"
+              ? error
+              : "";
+
+        const isFatalError =
+          status === 401 ||
+          status === 403 ||
+          message.includes("Unauthorized") ||
+          message.includes("Forbidden") ||
+          message.includes("Not Found") ||
+          message.includes("does not exist") ||
+          message.includes("WebGL");
+
+        if (isFatalError) {
           recordMapOutcome("load_error");
           setMapError("The map could not be loaded.");
         }

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -82,7 +82,6 @@ export default function FacilityMap({
         antialias: true,
       });
       let hasLoaded = false;
-      let isStyleLoaded = false;
 
       const MAP_LOAD_TIMEOUT_MS = 10000;
       timeoutId = window.setTimeout(() => {
@@ -95,25 +94,12 @@ export default function FacilityMap({
 
       map.current = mapInstance;
 
-      mapInstance.on("style.load", () => {
-        isStyleLoaded = true;
-      });
-
       mapInstance.on("error", (event) => {
         console.error("Mapbox error:", event.error);
-        if (hasLoaded) return;
-
-        const styleLoaded = isStyleLoaded || mapInstance.isStyleLoaded();
-        if (!styleLoaded) {
-          window.clearTimeout(timeoutId);
-          recordMapOutcome("load_error");
-          setMapError("The map could not be loaded.");
-        }
       });
 
       mapInstance.on("load", () => {
         hasLoaded = true;
-        isStyleLoaded = true;
         window.clearTimeout(timeoutId);
         recordMapOutcome("success");
         if (trackInitialLoadRef.current && !mapReadyRecorded.current) {

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -72,6 +72,8 @@ export default function FacilityMap({
 
     mapboxgl.accessToken = token;
 
+    let timeoutId: number | undefined;
+
     try {
       const mapInstance = new mapboxgl.Map({
         container: mapContainer.current,
@@ -80,35 +82,30 @@ export default function FacilityMap({
         antialias: true,
       });
       let hasLoaded = false;
+      let isStyleLoaded = false;
+
+      const MAP_LOAD_TIMEOUT_MS = 10000;
+      timeoutId = window.setTimeout(() => {
+        if (!hasLoaded) {
+          console.warn("Mapbox load timed out");
+          recordMapOutcome("load_error");
+          setMapError("The map could not be loaded.");
+        }
+      }, MAP_LOAD_TIMEOUT_MS);
 
       map.current = mapInstance;
+
+      mapInstance.on("style.load", () => {
+        isStyleLoaded = true;
+      });
 
       mapInstance.on("error", (event) => {
         console.error("Mapbox error:", event.error);
         if (hasLoaded) return;
 
-        const error = event.error;
-        let status: unknown;
-        if (error && typeof error === "object" && "status" in error) {
-          status = error.status;
-        }
-        const message =
-          error instanceof Error
-            ? error.message
-            : typeof error === "string"
-              ? error
-              : "";
-
-        const isFatalError =
-          status === 401 ||
-          status === 403 ||
-          message.includes("Unauthorized") ||
-          message.includes("Forbidden") ||
-          message.includes("Not Found") ||
-          message.includes("does not exist") ||
-          message.includes("WebGL");
-
-        if (isFatalError) {
+        const styleLoaded = isStyleLoaded || mapInstance.isStyleLoaded();
+        if (!styleLoaded) {
+          window.clearTimeout(timeoutId);
           recordMapOutcome("load_error");
           setMapError("The map could not be loaded.");
         }
@@ -116,6 +113,8 @@ export default function FacilityMap({
 
       mapInstance.on("load", () => {
         hasLoaded = true;
+        isStyleLoaded = true;
+        window.clearTimeout(timeoutId);
         recordMapOutcome("success");
         if (trackInitialLoadRef.current && !mapReadyRecorded.current) {
           mapReadyRecorded.current = true;
@@ -123,7 +122,6 @@ export default function FacilityMap({
         }
         setMapError(null);
         setIsMapLoaded(true);
-
         // Hide/show POI labels depending on zoom level using Mapbox Standard basemap config
         const POI_MIN_VISIBLE_ZOOM = 17; // Hide POI labels below this zoom
 
@@ -159,6 +157,7 @@ export default function FacilityMap({
     }
 
     return () => {
+      window.clearTimeout(timeoutId);
       if (map.current) {
         map.current.remove();
         map.current = null;

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -20,6 +20,15 @@ describe("server application", () => {
     expect(await response.json()).toEqual({ error: "API route not found" });
   });
 
+  it("sets secure headers with cross-origin referrer policy", async () => {
+    const response = await createApp().request("/api/health");
+
+    expect(response.headers.get("referrer-policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
 
   it("redirects raw fly.dev staging domain to staging.illinispots.com", async () => {
     const previousNodeEnv = process.env.NODE_ENV;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -31,7 +31,12 @@ export function createApp(dependencies: AppDependencies = {}) {
   app.use(sentryTracing(app));
   app.use("*", requestId());
   app.use("*", sentryRequestContext());
-  app.use("*", secureHeaders());
+  app.use(
+    "*",
+    secureHeaders({
+      referrerPolicy: "strict-origin-when-cross-origin",
+    }),
+  );
 
   if (!isTest) {
     app.use("*", logger());


### PR DESCRIPTION
This change fixes an issue where the map fails to load on mobile browsers, notably Safari on iOS.

The server's default `secureHeaders` middleware set `Referrer-Policy: no-referrer`, which prevented mobile browsers from sending the `Referer` header required by Mapbox token URL restrictions. Setting `referrerPolicy: "strict-origin-when-cross-origin"` allows Mapbox to validate the origin for API and style requests.

In `FacilityMap`, `mapInstance.on("error")` now logs errors to the console without preemptively aborting map loading on recoverable subresource warnings (such as missing optional sprites, glyphs, or slow tile requests). A 10-second load timeout handles unrecoverable initialization or network stalls, ensuring the loading overlay never hangs indefinitely while avoiding false-positive error flashes on transient warnings.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts the map-loading lifecycle and the server referrer policy to improve Mapbox behavior on mobile browsers.
- Adds a bounded map-loading timeout with late-load recovery.
- Treats Mapbox error events as non-fatal diagnostics.
- Configures `strict-origin-when-cross-origin` and verifies the resulting security headers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/map.tsx | Adds timeout-based recovery and changes Mapbox error events to diagnostic logging. |
| src/server/app.ts | Overrides the secure-headers referrer policy with strict-origin-when-cross-origin. |
| src/server/app.test.ts | Verifies the configured referrer policy and retained content-type protection. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Create Mapbox map] --> B[Start 10-second timeout]
  B --> C{Load occurs in time?}
  C -->|Yes| D[Clear timeout and show map]
  C -->|No| E[Show unavailable state]
  E --> F{Late load occurs?}
  F -->|Yes| D
  F -->|No| E
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(map): Avoid declaring fatal error on..."](https://github.com/plon/illinispots/commit/dea47f7f0cdd720c0ce613a3e0d21a432b8a7474) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55794507)</sub>

<!-- /greptile_comment -->