### PR TITLE
feat(availability): Keep current room status live

### DIFF
--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -14,6 +14,7 @@ import moment from "moment-timezone";
 import LeftSidebar from "@/components/left";
 import { FacilityStatus, FacilityType } from "@/types";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
+import { projectFacilityStatus } from "@/utils/liveAvailability";
 import {
   recordInitialLoadMilestone,
   type InitialLoadMilestone,
@@ -59,7 +60,8 @@ const fetchFacilityData = async (
 };
 
 const IlliniSpotsPage: React.FC = () => {
-  const { selectedDateTime } = useDateTimeContext();
+  const { selectedDateTime, isCurrentDateTime } = useDateTimeContext();
+  const [currentTime, setCurrentTime] = useState(() => new Date());
   const [showMapPreference, setShowMapPreference] = useState<boolean | null>(
     null,
   );
@@ -135,6 +137,23 @@ const IlliniSpotsPage: React.FC = () => {
     };
   }, [academicData, libraryData]);
 
+  useEffect(() => {
+    if (!isCurrentDateTime) return;
+
+    const updateCurrentTime = () => setCurrentTime(new Date());
+    updateCurrentTime();
+    const intervalId = window.setInterval(updateCurrentTime, 30_000);
+    return () => window.clearInterval(intervalId);
+  }, [isCurrentDateTime]);
+
+  const displayedFacilityData = useMemo(
+    () =>
+      facilityData && isCurrentDateTime
+        ? projectFacilityStatus(facilityData, currentTime)
+        : facilityData,
+    [currentTime, facilityData, isCurrentDateTime],
+  );
+
   const error = academicQueryError ? academicQueryError.message : null;
 
   useEffect(() => {
@@ -209,7 +228,7 @@ const IlliniSpotsPage: React.FC = () => {
         <div className="h-[40vh] md:h-screen md:w-[63%] w-full order-1 md:order-2">
           <Suspense fallback={<MapLoadingFallback />}>
             <FacilityMap
-              facilityData={facilityData || null}
+              facilityData={displayedFacilityData || null}
               onMarkerClick={handleMarkerClick}
               trackInitialLoad={true}
             />
@@ -223,7 +242,7 @@ const IlliniSpotsPage: React.FC = () => {
         } w-full flex-1 overflow-hidden order-2 md:order-1 relative`}
       >
         <LeftSidebar
-          facilityData={facilityData || null}
+          facilityData={displayedFacilityData || null}
           expandedItems={expandedItems}
           setExpandedItems={setExpandedItems}
           showMap={showMap}

--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -15,6 +15,7 @@ import LeftSidebar from "@/components/left";
 import { FacilityStatus, FacilityType } from "@/types";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
 import { projectFacilityStatus } from "@/utils/liveAvailability";
+import { useCurrentMinute } from "@/hooks/useCurrentMinute";
 import {
   recordInitialLoadMilestone,
   type InitialLoadMilestone,
@@ -61,7 +62,7 @@ const fetchFacilityData = async (
 
 const IlliniSpotsPage: React.FC = () => {
   const { selectedDateTime, isCurrentDateTime } = useDateTimeContext();
-  const [currentTime, setCurrentTime] = useState(() => new Date());
+  const currentTime = useCurrentMinute(isCurrentDateTime);
   const [showMapPreference, setShowMapPreference] = useState<boolean | null>(
     null,
   );
@@ -136,15 +137,6 @@ const IlliniSpotsPage: React.FC = () => {
       },
     };
   }, [academicData, libraryData]);
-
-  useEffect(() => {
-    if (!isCurrentDateTime) return;
-
-    const updateCurrentTime = () => setCurrentTime(new Date());
-    updateCurrentTime();
-    const intervalId = window.setInterval(updateCurrentTime, 30_000);
-    return () => window.clearInterval(intervalId);
-  }, [isCurrentDateTime]);
 
   const displayedFacilityData = useMemo(
     () =>

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -83,9 +83,15 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
             minDuration,
             freeUntil: freeUntil || undefined,
             startTime: startTime || undefined,
-            now: moment(selectedDateTime),
+            now: moment(facilityData?.timestamp ?? selectedDateTime),
         }),
-        [minDuration, freeUntil, startTime, selectedDateTime],
+        [
+            minDuration,
+            freeUntil,
+            startTime,
+            facilityData?.timestamp,
+            selectedDateTime,
+        ],
     );
 
     const hasActiveFilters = !!minDuration || !!freeUntil || !!startTime;

--- a/src/contexts/DateTimeContext.tsx
+++ b/src/contexts/DateTimeContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useState, ReactNode } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  ReactNode,
+} from "react";
 import moment from "moment-timezone";
 
 interface DateTimeContextType {
@@ -14,6 +20,12 @@ const DateTimeContext = createContext<DateTimeContextType | undefined>(undefined
 
 export function DateTimeProvider({ children }: { children: ReactNode }) {
   const [selectedDateTime, setSelectedDateTime] = useState<Date>(new Date());
+  const [isCurrentDateTime, setIsCurrentDateTime] = useState(true);
+
+  const selectDateTime = useCallback((date: Date) => {
+    setSelectedDateTime(date);
+    setIsCurrentDateTime(Math.abs(date.getTime() - Date.now()) < 60_000);
+  }, []);
 
   // Format the date as YYYY-MM-DD for API calls
   const formattedDate = moment(selectedDateTime).format("YYYY-MM-DD");
@@ -21,27 +33,20 @@ export function DateTimeProvider({ children }: { children: ReactNode }) {
   // Format the time as HH:mm:ss for API calls
   const formattedTime = moment(selectedDateTime).format("HH:mm:ss");
 
-  // Check if the selected date/time is the current date/time (within 1 minute)
-  const isCurrentDateTime = () => {
-    const now = new Date();
-    const diffMs = Math.abs(selectedDateTime.getTime() - now.getTime());
-    const diffMinutes = diffMs / (1000 * 60);
-    return diffMinutes < 1;
-  };
-
   // Reset to current date/time
   const resetToCurrentDateTime = () => {
     setSelectedDateTime(new Date());
+    setIsCurrentDateTime(true);
   };
 
   return (
     <DateTimeContext.Provider
       value={{
         selectedDateTime,
-        setSelectedDateTime,
+        setSelectedDateTime: selectDateTime,
         formattedDate,
         formattedTime,
-        isCurrentDateTime: isCurrentDateTime(),
+        isCurrentDateTime,
         resetToCurrentDateTime,
       }}
     >

--- a/src/hooks/useCurrentMinute.test.ts
+++ b/src/hooks/useCurrentMinute.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { millisecondsUntilNextMinute } from "@/hooks/useCurrentMinute";
+
+describe("millisecondsUntilNextMinute", () => {
+  it("waits one full minute when already on a minute boundary", () => {
+    expect(millisecondsUntilNextMinute(120_000)).toBe(60_000);
+  });
+
+  it("aligns a timeout to the next minute boundary", () => {
+    expect(millisecondsUntilNextMinute(120_001)).toBe(59_999);
+    expect(millisecondsUntilNextMinute(179_999)).toBe(1);
+  });
+});

--- a/src/hooks/useCurrentMinute.ts
+++ b/src/hooks/useCurrentMinute.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+
+const MINUTE_MS = 60_000;
+
+export function millisecondsUntilNextMinute(nowMs: number): number {
+  const elapsedInMinute = ((nowMs % MINUTE_MS) + MINUTE_MS) % MINUTE_MS;
+  return elapsedInMinute === 0 ? MINUTE_MS : MINUTE_MS - elapsedInMinute;
+}
+
+/**
+ * Exposes wall-clock time as React state at the precision displayed by the UI.
+ * The timeout is realigned after every tick and whenever the page resumes, so
+ * background-tab throttling and timer drift cannot leave availability stale.
+ */
+export function useCurrentMinute(enabled: boolean): Date {
+  const [currentTime, setCurrentTime] = useState(() => new Date());
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let timeoutId: number | undefined;
+
+    const scheduleNextMinute = () => {
+      window.clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(() => {
+        setCurrentTime(new Date());
+        scheduleNextMinute();
+      }, millisecondsUntilNextMinute(Date.now()));
+    };
+
+    const synchronize = () => {
+      setCurrentTime(new Date());
+      scheduleNextMinute();
+    };
+
+    const synchronizeVisiblePage = () => {
+      if (document.visibilityState === "visible") synchronize();
+    };
+
+    synchronize();
+    window.addEventListener("focus", synchronize);
+    window.addEventListener("pageshow", synchronize);
+    document.addEventListener("visibilitychange", synchronizeVisiblePage);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.removeEventListener("focus", synchronize);
+      window.removeEventListener("pageshow", synchronize);
+      document.removeEventListener("visibilitychange", synchronizeVisiblePage);
+    };
+  }, [enabled]);
+
+  return currentTime;
+}

--- a/src/utils/liveAvailability.test.ts
+++ b/src/utils/liveAvailability.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "bun:test";
+import moment from "moment-timezone";
+import {
+  type Facility,
+  type FacilityStatus,
+  FacilityType,
+  RoomStatus,
+} from "@/types";
+import { projectFacilityStatus } from "@/utils/liveAvailability";
+
+const CAMPUS_TIMEZONE = "America/Chicago";
+
+function atCampusTime(value: string): Date {
+  return moment.tz(value, "YYYY-MM-DD HH:mm:ss", CAMPUS_TIMEZONE).toDate();
+}
+
+function statusWith(facility: Facility, timestamp = "2026-08-24 10:00:00"): FacilityStatus {
+  return {
+    timestamp: moment
+      .tz(timestamp, "YYYY-MM-DD HH:mm:ss", CAMPUS_TIMEZONE)
+      .toISOString(),
+    facilities: { [facility.id]: facility },
+  };
+}
+
+describe("projectFacilityStatus", () => {
+  it("decrements an available academic room and enters its next class", () => {
+    const snapshot = statusWith({
+      id: "siebel",
+      name: "Siebel Center",
+      type: FacilityType.ACADEMIC,
+      coordinates: { latitude: 0, longitude: 0 },
+      hours: { open: "08:00:00", close: "22:00:00" },
+      isOpen: true,
+      roomCounts: { available: 1, total: 1 },
+      rooms: {
+        "1101": {
+          type: "academic",
+          status: RoomStatus.AVAILABLE,
+          availableFor: 30,
+          availableUntil: "10:30:00",
+          nextClass: {
+            course: "CS 225",
+            title: "Data Structures",
+            time: { start: "10:30:00", end: "11:20:00" },
+          },
+        },
+      },
+    });
+
+    const duringGap = projectFacilityStatus(
+      snapshot,
+      atCampusTime("2026-08-24 10:10:30"),
+    );
+    expect(duringGap.facilities.siebel.rooms["1101"]).toMatchObject({
+      status: RoomStatus.PASSING_PERIOD,
+      availableFor: 20,
+      passingPeriod: true,
+    });
+
+    const duringClass = projectFacilityStatus(
+      snapshot,
+      atCampusTime("2026-08-24 10:35:00"),
+    );
+    expect(duringClass.facilities.siebel.rooms["1101"]).toMatchObject({
+      status: RoomStatus.OCCUPIED,
+      currentClass: { course: "CS 225" },
+    });
+    expect(duringClass.facilities.siebel.roomCounts.available).toBe(0);
+  });
+
+  it("makes an occupied academic room available at its loaded boundary", () => {
+    const snapshot = statusWith({
+      id: "cif",
+      name: "Campus Instructional Facility",
+      type: FacilityType.ACADEMIC,
+      coordinates: { latitude: 0, longitude: 0 },
+      hours: { open: "07:00:00", close: "22:00:00" },
+      isOpen: true,
+      roomCounts: { available: 0, total: 1 },
+      rooms: {
+        "0027": {
+          type: "academic",
+          status: RoomStatus.OPENING_SOON,
+          currentClass: {
+            course: "MATH 241",
+            title: "Calculus III",
+            time: { start: "09:00:00", end: "10:10:00" },
+          },
+          availableAt: "10:10:00",
+          availableFor: 50,
+        },
+      },
+    });
+
+    const projected = projectFacilityStatus(
+      snapshot,
+      atCampusTime("2026-08-24 10:20:00"),
+    );
+    expect(projected.facilities.cif.rooms["0027"]).toMatchObject({
+      status: RoomStatus.AVAILABLE,
+      availableFor: 40,
+      availableUntil: "11:00:00",
+    });
+    expect(projected.facilities.cif.roomCounts.available).toBe(1);
+  });
+
+  it("recomputes library room status from the loaded reservation slots", () => {
+    const snapshot = statusWith({
+      id: "grainger",
+      name: "Grainger Engineering Library",
+      type: FacilityType.LIBRARY,
+      coordinates: { latitude: 0, longitude: 0 },
+      hours: { open: "08:00", close: "23:59" },
+      isOpen: true,
+      roomCounts: { available: 0, total: 1 },
+      rooms: {
+        "407": {
+          type: "library",
+          status: RoomStatus.RESERVED,
+          url: "https://example.com",
+          thumbnail: "",
+          slots: [
+            { start: "10:00:00", end: "10:30:00", available: false },
+            { start: "10:30:00", end: "11:00:00", available: true },
+            { start: "11:00:00", end: "11:30:00", available: true },
+          ],
+        },
+      },
+    });
+
+    const openingSoon = projectFacilityStatus(
+      snapshot,
+      atCampusTime("2026-08-24 10:15:00"),
+    );
+    expect(openingSoon.facilities.grainger.rooms["407"]).toMatchObject({
+      status: RoomStatus.OPENING_SOON,
+      availableAt: "10:30:00",
+      availableFor: 60,
+    });
+
+    const available = projectFacilityStatus(
+      snapshot,
+      atCampusTime("2026-08-24 10:45:00"),
+    );
+    expect(available.facilities.grainger.rooms["407"]).toMatchObject({
+      status: RoomStatus.AVAILABLE,
+      availableFor: 45,
+    });
+    expect(available.facilities.grainger.roomCounts.available).toBe(1);
+    expect(available.timestamp).toBe(
+      moment(atCampusTime("2026-08-24 10:45:00"))
+        .tz(CAMPUS_TIMEZONE)
+        .toISOString(),
+    );
+  });
+
+  it("handles loaded library slots that cross midnight", () => {
+    const snapshot = statusWith(
+      {
+        id: "aces",
+        name: "Funk ACES Library",
+        type: FacilityType.LIBRARY,
+        coordinates: { latitude: 0, longitude: 0 },
+        hours: { open: "08:30", close: "02:00" },
+        isOpen: true,
+        roomCounts: { available: 0, total: 1 },
+        rooms: {
+          "301": {
+            type: "library",
+            status: RoomStatus.RESERVED,
+            url: "https://example.com",
+            thumbnail: "",
+            slots: [
+              { start: "23:30:00", end: "00:00:00", available: false },
+              { start: "00:00:00", end: "01:00:00", available: true },
+            ],
+          },
+        },
+      },
+      "2026-08-24 23:30:00",
+    );
+
+    const projected = projectFacilityStatus(
+      snapshot,
+      atCampusTime("2026-08-25 00:15:00"),
+    );
+    expect(projected.facilities.aces.rooms["301"]).toMatchObject({
+      status: RoomStatus.AVAILABLE,
+      availableFor: 45,
+    });
+  });
+
+  it("does not mutate the loaded query value", () => {
+    const snapshot = statusWith({
+      id: "empty",
+      name: "Empty Building",
+      type: FacilityType.ACADEMIC,
+      coordinates: { latitude: 0, longitude: 0 },
+      hours: { open: "08:00:00", close: "17:00:00" },
+      isOpen: true,
+      roomCounts: { available: 0, total: 0 },
+      rooms: {},
+    });
+
+    const projected = projectFacilityStatus(
+      snapshot,
+      atCampusTime("2026-08-24 18:00:00"),
+    );
+    expect(snapshot.facilities.empty.isOpen).toBe(true);
+    expect(projected.facilities.empty.isOpen).toBe(false);
+  });
+});

--- a/src/utils/liveAvailability.ts
+++ b/src/utils/liveAvailability.ts
@@ -1,0 +1,315 @@
+import moment, { type Moment } from "moment-timezone";
+import {
+  type AcademicRoom,
+  type ClassInfo,
+  type Facility,
+  type FacilityRoom,
+  type FacilityStatus,
+  FacilityType,
+  type LibraryRoom,
+  RoomStatus,
+  type TimeSlot,
+} from "@/types";
+import { isLibraryOpen } from "@/utils/libraryHours";
+
+const CAMPUS_TIMEZONE = "America/Chicago";
+const OPENING_SOON_MINUTES = 20;
+const PASSING_PERIOD_MINUTES = 30;
+
+function timeOnReferenceDate(time: string, reference: Moment): Moment {
+  return moment.tz(
+    `${reference.format("YYYY-MM-DD")} ${time}`,
+    "YYYY-MM-DD HH:mm:ss",
+    CAMPUS_TIMEZONE,
+  );
+}
+
+function classInterval(info: ClassInfo | undefined, reference: Moment) {
+  if (!info?.time) return null;
+  const start = timeOnReferenceDate(info.time.start, reference);
+  const end = timeOnReferenceDate(info.time.end, reference);
+  if (end.isSameOrBefore(start)) end.add(1, "day");
+  return { info, start, end };
+}
+
+function remainingMinutes(end: Moment, now: Moment): number {
+  return Math.max(0, Math.ceil(end.diff(now, "seconds") / 60));
+}
+
+function projectAcademicRoom(
+  room: AcademicRoom,
+  reference: Moment,
+  now: Moment,
+): AcademicRoom {
+  const currentInterval = classInterval(room.currentClass, reference);
+  const nextInterval = classInterval(room.nextClass, reference);
+  const activeInterval = [currentInterval, nextInterval].find(
+    (interval) =>
+      interval &&
+      now.isSameOrAfter(interval.start) &&
+      now.isBefore(interval.end),
+  );
+
+  if (activeInterval) {
+    const nextBecameCurrent = activeInterval === nextInterval;
+    return {
+      ...room,
+      status: RoomStatus.OCCUPIED,
+      passingPeriod: false,
+      currentClass: activeInterval.info,
+      nextClass: nextBecameCurrent ? undefined : room.nextClass,
+      availableAt: nextBecameCurrent ? undefined : room.availableAt,
+      availableFor: nextBecameCurrent ? undefined : room.availableFor,
+      availableUntil: undefined,
+    };
+  }
+
+  const wasAvailable =
+    room.status === RoomStatus.AVAILABLE ||
+    room.status === RoomStatus.PASSING_PERIOD;
+  const availabilityStart = wasAvailable
+    ? reference.clone()
+    : room.availableAt
+      ? timeOnReferenceDate(room.availableAt, reference)
+      : null;
+  let availabilityEnd = room.availableUntil
+    ? timeOnReferenceDate(room.availableUntil, reference)
+    : availabilityStart && room.availableFor !== undefined
+      ? availabilityStart.clone().add(room.availableFor, "minutes")
+      : null;
+
+  if (
+    availabilityStart &&
+    availabilityEnd &&
+    availabilityEnd.isSameOrBefore(availabilityStart)
+  ) {
+    availabilityEnd = availabilityEnd.add(1, "day");
+  }
+
+  if (
+    availabilityStart &&
+    availabilityEnd &&
+    now.isSameOrAfter(availabilityStart) &&
+    now.isBefore(availabilityEnd)
+  ) {
+    const availableFor = remainingMinutes(availabilityEnd, now);
+    const isPassingPeriod =
+      availableFor < PASSING_PERIOD_MINUTES &&
+      !!nextInterval &&
+      nextInterval.start.isSameOrBefore(availabilityEnd);
+
+    return {
+      ...room,
+      status: isPassingPeriod
+        ? RoomStatus.PASSING_PERIOD
+        : RoomStatus.AVAILABLE,
+      passingPeriod: isPassingPeriod,
+      currentClass: undefined,
+      availableAt: undefined,
+      availableFor,
+      availableUntil: availabilityEnd.format("HH:mm:ss"),
+    };
+  }
+
+  if (availabilityStart && now.isBefore(availabilityStart)) {
+    const minutesUntilAvailable = Math.ceil(
+      availabilityStart.diff(now, "seconds") / 60,
+    );
+    return {
+      ...room,
+      status:
+        minutesUntilAvailable <= OPENING_SOON_MINUTES &&
+        (room.availableFor ?? 0) >= PASSING_PERIOD_MINUTES
+          ? RoomStatus.OPENING_SOON
+          : RoomStatus.OCCUPIED,
+    };
+  }
+
+  // The snapshot only carries the current and next academic activity. Once
+  // those known intervals have elapsed, keep the conservative occupied state
+  // rather than claiming the room is free without schedule data to prove it.
+  if (!wasAvailable && availabilityEnd && now.isSameOrAfter(availabilityEnd)) {
+    return {
+      ...room,
+      status: RoomStatus.OCCUPIED,
+      passingPeriod: false,
+      currentClass: undefined,
+      availableAt: undefined,
+      availableFor: undefined,
+      availableUntil: undefined,
+    };
+  }
+
+  return room;
+}
+
+interface DatedSlot {
+  slot: TimeSlot;
+  start: Moment;
+  end: Moment;
+}
+
+function dateLibrarySlots(slots: TimeSlot[], reference: Moment): DatedSlot[] {
+  let previousStart: Moment | null = null;
+
+  return slots.map((slot, index) => {
+    const start = timeOnReferenceDate(slot.start, reference);
+    const end = timeOnReferenceDate(slot.end, reference);
+    if (end.isSameOrBefore(start)) end.add(1, "day");
+
+    if (index === 0 && end.isSameOrBefore(reference)) {
+      start.add(1, "day");
+      end.add(1, "day");
+    } else if (previousStart && start.isBefore(previousStart)) {
+      start.add(1, "day");
+      end.add(1, "day");
+    }
+
+    previousStart = start;
+    return { slot, start, end };
+  });
+}
+
+function availableBlockDuration(
+  slots: DatedSlot[],
+  startIndex: number,
+  from: Moment,
+): number {
+  let end = slots[startIndex].end.clone();
+
+  for (let index = startIndex + 1; index < slots.length; index++) {
+    const next = slots[index];
+    if (!next.slot.available || !next.start.isSame(end)) break;
+    end = next.end.clone();
+  }
+
+  return remainingMinutes(end, from);
+}
+
+function projectLibraryRoom(
+  room: LibraryRoom,
+  reference: Moment,
+  now: Moment,
+): LibraryRoom {
+  if (room.slots.length === 0) return room;
+
+  const slots = dateLibrarySlots(room.slots, reference);
+  const activeIndex = slots.findIndex(
+    ({ start, end }) => now.isSameOrAfter(start) && now.isBefore(end),
+  );
+
+  if (activeIndex >= 0 && slots[activeIndex].slot.available) {
+    return {
+      ...room,
+      status: RoomStatus.AVAILABLE,
+      availableAt: undefined,
+      availableFor: availableBlockDuration(slots, activeIndex, now),
+    };
+  }
+
+  const futureAvailableIndex = slots.findIndex(
+    ({ slot, start }) => slot.available && start.isAfter(now),
+  );
+  if (futureAvailableIndex < 0) {
+    return {
+      ...room,
+      status: RoomStatus.RESERVED,
+      availableAt: undefined,
+      availableFor: 0,
+    };
+  }
+
+  const availableStart = slots[futureAvailableIndex].start;
+  const availableFor = availableBlockDuration(
+    slots,
+    futureAvailableIndex,
+    availableStart,
+  );
+  const minutesUntilAvailable = Math.ceil(
+    availableStart.diff(now, "seconds") / 60,
+  );
+
+  return {
+    ...room,
+    status:
+      minutesUntilAvailable <= OPENING_SOON_MINUTES &&
+      availableFor >= PASSING_PERIOD_MINUTES
+        ? RoomStatus.OPENING_SOON
+        : RoomStatus.RESERVED,
+    availableAt: availableStart.format("HH:mm:ss"),
+    availableFor,
+  };
+}
+
+function isAcademicFacilityStillOpen(
+  facility: Facility,
+  reference: Moment,
+  now: Moment,
+): boolean {
+  if (!facility.hours.open || !facility.hours.close) return facility.isOpen;
+  const open = timeOnReferenceDate(facility.hours.open, reference);
+  const close = timeOnReferenceDate(facility.hours.close, reference);
+  if (close.isSameOrBefore(open)) close.add(1, "day");
+  return now.isSameOrAfter(open) && now.isBefore(close);
+}
+
+function projectFacility(
+  facility: Facility,
+  reference: Moment,
+  now: Moment,
+): Facility {
+  // A closed snapshot has no room schedule payload, so it cannot safely be
+  // advanced into an open state without another request.
+  const isOpen =
+    facility.isOpen &&
+    (facility.type === FacilityType.LIBRARY
+      ? isLibraryOpen(facility.name, now)
+      : isAcademicFacilityStillOpen(facility, reference, now));
+
+  const rooms = Object.fromEntries(
+    Object.entries(facility.rooms).map(([roomName, room]): [string, FacilityRoom] => [
+      roomName,
+      room.type === "library"
+        ? projectLibraryRoom(room, reference, now)
+        : projectAcademicRoom(room, reference, now),
+    ]),
+  );
+  const available = isOpen
+    ? Object.values(rooms).filter(
+        (room) =>
+          room.status === RoomStatus.AVAILABLE ||
+          room.status === RoomStatus.PASSING_PERIOD,
+      ).length
+    : 0;
+
+  return {
+    ...facility,
+    isOpen,
+    rooms,
+    roomCounts: { ...facility.roomCounts, available },
+  };
+}
+
+/**
+ * Advances a loaded availability snapshot using only its existing schedule
+ * boundaries. It never performs I/O and never mutates the query cache value.
+ */
+export function projectFacilityStatus(
+  status: FacilityStatus,
+  currentTime: Date,
+): FacilityStatus {
+  const reference = moment(status.timestamp).tz(CAMPUS_TIMEZONE);
+  const now = moment(currentTime).tz(CAMPUS_TIMEZONE);
+  if (!reference.isValid() || now.isBefore(reference)) return status;
+
+  return {
+    ...status,
+    timestamp: now.toISOString(),
+    facilities: Object.fromEntries(
+      Object.entries(status.facilities).map(([id, facility]) => [
+        id,
+        projectFacility(facility, reference, now),
+      ]),
+    ),
+  };
+}


### PR DESCRIPTION
Availability shown for “Now” now advances at each minute boundary from the
academic class boundaries and library reservation slots already loaded in the
browser. Room badges and countdowns, building counts, map markers, search
results, and availability filters therefore remain consistent as time passes;
explicitly selected past or future times remain static.

The projection is local-only and does not poll or refresh either facilities
endpoint. The shared clock realigns after every update and resynchronizes when
the tab regains focus, becomes visible, or returns from browser history so
background timer throttling cannot leave durations stale. Academic snapshots
are advanced only across boundaries supported by their loaded current/next
activity data, while library snapshots are recomputed from their loaded slots,
including overnight schedules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Facility availability now updates automatically as the current time changes.
  * Maps and sidebars display projected room and facility statuses for the selected time.
  * Live updates stay synchronized when returning to or refocusing the page.
  * Overnight schedules, opening-soon periods, passing periods, and reservation slots are reflected more accurately.

* **Bug Fixes**
  * Preserved availability snapshots are no longer modified while calculating projected statuses.
  * Current-time filtering now uses the most accurate available timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->