### PR TITLE
feat(availability): Keep live facility data current

### DIFF
--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -18,6 +18,10 @@ import {
   recordInitialLoadMilestone,
   type InitialLoadMilestone,
 } from "@/utils/loadingMetrics";
+import {
+  ageLiveAvailability,
+  LIVE_REFRESH_INTERVAL_MS,
+} from "@/utils/liveUpdates";
 
 const FacilityMap = lazy(() => import("@/components/map"));
 
@@ -59,7 +63,7 @@ const fetchFacilityData = async (
 };
 
 const IlliniSpotsPage: React.FC = () => {
-  const { selectedDateTime } = useDateTimeContext();
+  const { selectedDateTime, isCurrentDateTime } = useDateTimeContext();
   const [showMapPreference, setShowMapPreference] = useState<boolean | null>(
     null,
   );
@@ -89,9 +93,17 @@ const IlliniSpotsPage: React.FC = () => {
     isSuccess: isAcademicSuccess,
     refetch: refetchAcademic,
   } = useQuery<FacilityStatus, Error>({
-    queryKey: ["facilities", "academic", selectedDateTime.toISOString()],
-    queryFn: () => fetchFacilityData(selectedDateTime, "academic"),
-    staleTime: 5 * 60 * 1000,
+    queryKey: [
+      "facilities",
+      "academic",
+      isCurrentDateTime ? "live" : selectedDateTime.toISOString(),
+    ],
+    queryFn: () =>
+      fetchFacilityData(
+        isCurrentDateTime ? new Date() : selectedDateTime,
+        "academic",
+      ),
+    staleTime: isCurrentDateTime ? 0 : 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -103,10 +115,19 @@ const IlliniSpotsPage: React.FC = () => {
     data: libraryData,
     isFetching: isLibraryFetching,
     isSuccess: isLibrarySuccess,
+    refetch: refetchLibrary,
   } = useQuery<FacilityStatus, Error>({
-    queryKey: ["facilities", "library", selectedDateTime.toISOString()],
-    queryFn: () => fetchFacilityData(selectedDateTime, "library"),
-    staleTime: 5 * 60 * 1000,
+    queryKey: [
+      "facilities",
+      "library",
+      isCurrentDateTime ? "live" : selectedDateTime.toISOString(),
+    ],
+    queryFn: () =>
+      fetchFacilityData(
+        isCurrentDateTime ? new Date() : selectedDateTime,
+        "library",
+      ),
+    staleTime: isCurrentDateTime ? 0 : 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
@@ -115,25 +136,76 @@ const IlliniSpotsPage: React.FC = () => {
   });
 
   const facilityData = useMemo<FacilityStatus | undefined>(() => {
-    if (!academicData && !libraryData) {
+    const currentAcademicData = isCurrentDateTime
+      ? ageLiveAvailability(academicData, selectedDateTime)
+      : academicData;
+    const currentLibraryData = isCurrentDateTime
+      ? ageLiveAvailability(libraryData, selectedDateTime)
+      : libraryData;
+
+    if (!currentAcademicData && !currentLibraryData) {
       return undefined;
     }
 
     const matchingLibraryFacilities =
-      !academicData ||
-      !libraryData ||
-      libraryData.timestamp === academicData.timestamp
-        ? libraryData?.facilities || {}
+      isCurrentDateTime ||
+      !currentAcademicData ||
+      !currentLibraryData ||
+      currentLibraryData.timestamp === currentAcademicData.timestamp
+        ? currentLibraryData?.facilities || {}
         : {};
 
     return {
-      timestamp: academicData?.timestamp || libraryData?.timestamp || "",
+      timestamp:
+        currentAcademicData?.timestamp || currentLibraryData?.timestamp || "",
       facilities: {
-        ...(academicData?.facilities || {}),
+        ...(currentAcademicData?.facilities || {}),
         ...matchingLibraryFacilities,
       },
     };
-  }, [academicData, libraryData]);
+  }, [academicData, isCurrentDateTime, libraryData, selectedDateTime]);
+
+  useEffect(() => {
+    if (!isCurrentDateTime) return;
+
+    let timeoutId: number | undefined;
+    let cancelled = false;
+
+    const stopTimer = () => {
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
+    const scheduleNextRefresh = () => {
+      stopTimer();
+      if (cancelled || document.visibilityState !== "visible") return;
+
+      timeoutId = window.setTimeout(() => {
+        timeoutId = undefined;
+        void Promise.all([refetchAcademic(), refetchLibrary()]).finally(
+          scheduleNextRefresh,
+        );
+      }, LIVE_REFRESH_INTERVAL_MS);
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void Promise.all([refetchAcademic(), refetchLibrary()]).finally(
+          scheduleNextRefresh,
+        );
+      } else {
+        stopTimer();
+      }
+    };
+
+    scheduleNextRefresh();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      cancelled = true;
+      stopTimer();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [isCurrentDateTime, refetchAcademic, refetchLibrary]);
 
   const error = academicQueryError ? academicQueryError.message : null;
 

--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -21,6 +21,7 @@ import {
 import {
   ageLiveAvailability,
   LIVE_REFRESH_INTERVAL_MS,
+  shouldRefetchFacilitiesOnReconnect,
 } from "@/utils/liveUpdates";
 
 const FacilityMap = lazy(() => import("@/components/map"));
@@ -107,7 +108,8 @@ const IlliniSpotsPage: React.FC = () => {
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
-    refetchOnReconnect: true,
+    refetchOnReconnect: () =>
+      shouldRefetchFacilitiesOnReconnect(isCurrentDateTime),
     placeholderData: keepPreviousData,
   });
 
@@ -131,7 +133,8 @@ const IlliniSpotsPage: React.FC = () => {
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
-    refetchOnReconnect: true,
+    refetchOnReconnect: () =>
+      shouldRefetchFacilitiesOnReconnect(isCurrentDateTime),
     placeholderData: keepPreviousData,
   });
 

--- a/src/components/DateTimeButton.tsx
+++ b/src/components/DateTimeButton.tsx
@@ -25,13 +25,22 @@ const DateTimeButton: React.FC<DateTimeButtonProps> = ({
     className,
     isFetching,
 }) => {
-    const { selectedDateTime, setSelectedDateTime, isCurrentDateTime } =
-        useDateTimeContext();
+    const {
+        selectedDateTime,
+        setSelectedDateTime,
+        isCurrentDateTime,
+        resetToCurrentDateTime,
+    } = useDateTimeContext();
     const [open, setOpen] = useState(false);
     const isDesktop = useMediaQuery("(min-width: 768px)");
 
     const handleDateTimeChange = (dateTime: Date) => {
         setSelectedDateTime(dateTime);
+        setOpen(false);
+    };
+
+    const handleResetToNow = () => {
+        resetToCurrentDateTime();
         setOpen(false);
     };
 
@@ -67,6 +76,7 @@ const DateTimeButton: React.FC<DateTimeButtonProps> = ({
         <DateTimePicker
             initialDateTime={selectedDateTime}
             onDateTimeChange={handleDateTimeChange}
+            onResetToNow={handleResetToNow}
             compact={true}
             isFetching={isFetching}
             closeContainer={closeContainer}

--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -9,6 +9,7 @@ import moment from "moment-timezone";
 interface DateTimePickerProps {
   initialDateTime?: Date;
   onDateTimeChange?: (dateTime: Date) => void;
+  onResetToNow?: () => void;
   showResetButton?: boolean;
   compact?: boolean;
   isFetching?: boolean;
@@ -18,6 +19,7 @@ interface DateTimePickerProps {
 function DateTimePicker({
   initialDateTime = new Date(),
   onDateTimeChange,
+  onResetToNow,
   showResetButton = true,
   compact = false,
   isFetching = false,
@@ -83,7 +85,10 @@ function DateTimePicker({
     now.setSeconds(0, 0);
     setLocalSelectedDate(now);
     setLocalTimeValue(moment(now).format("HH:mm"));
-    if (onDateTimeChange) {
+    if (onResetToNow) {
+      onResetToNow();
+      if (closeContainer) closeContainer();
+    } else if (onDateTimeChange) {
       onDateTimeChange(now);
       if (closeContainer) closeContainer();
     }

--- a/src/contexts/DateTimeContext.test.ts
+++ b/src/contexts/DateTimeContext.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import {
+  millisecondsUntilNextMinute,
+  startOfMinute,
+} from "./DateTimeContext";
+
+describe("live date/time helpers", () => {
+  it("normalizes live timestamps to the start of a minute", () => {
+    expect(startOfMinute(new Date("2026-08-23T12:34:56.789Z")).toISOString()).toBe(
+      "2026-08-23T12:34:00.000Z",
+    );
+  });
+
+  it("schedules the next update on the exact minute boundary", () => {
+    expect(
+      millisecondsUntilNextMinute(new Date("2026-08-23T12:34:56.789Z")),
+    ).toBe(3_211);
+    expect(
+      millisecondsUntilNextMinute(new Date("2026-08-23T12:35:00.000Z")),
+    ).toBe(60_000);
+  });
+});

--- a/src/contexts/DateTimeContext.test.ts
+++ b/src/contexts/DateTimeContext.test.ts
@@ -5,7 +5,7 @@ import {
 } from "./DateTimeContext";
 
 describe("live date/time helpers", () => {
-  it("normalizes live timestamps to the start of a minute", () => {
+  it("normalizes selected timestamps to the start of a minute", () => {
     expect(startOfMinute(new Date("2026-08-23T12:34:56.789Z")).toISOString()).toBe(
       "2026-08-23T12:34:00.000Z",
     );

--- a/src/contexts/DateTimeContext.tsx
+++ b/src/contexts/DateTimeContext.tsx
@@ -1,5 +1,24 @@
-import React, { createContext, useContext, useState, ReactNode } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from "react";
 import moment from "moment-timezone";
+
+const MINUTE_MS = 60_000;
+
+export function startOfMinute(date: Date): Date {
+  const minute = new Date(date);
+  minute.setSeconds(0, 0);
+  return minute;
+}
+
+export function millisecondsUntilNextMinute(date: Date): number {
+  return MINUTE_MS - (date.getTime() % MINUTE_MS);
+}
 
 interface DateTimeContextType {
   selectedDateTime: Date;
@@ -13,26 +32,72 @@ interface DateTimeContextType {
 const DateTimeContext = createContext<DateTimeContextType | undefined>(undefined);
 
 export function DateTimeProvider({ children }: { children: ReactNode }) {
-  const [selectedDateTime, setSelectedDateTime] = useState<Date>(new Date());
+  const [selectedDateTime, setSelectedDateTimeState] = useState<Date>(() =>
+    startOfMinute(new Date()),
+  );
+  const [isLive, setIsLive] = useState(true);
+
+  const setSelectedDateTime = useCallback((date: Date) => {
+    setIsLive(false);
+    setSelectedDateTimeState(date);
+  }, []);
+
+  const resetToCurrentDateTime = useCallback(() => {
+    setIsLive(true);
+    setSelectedDateTimeState(startOfMinute(new Date()));
+  }, []);
+
+  useEffect(() => {
+    if (!isLive) return;
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const stopTimer = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
+
+    const scheduleNextMinute = () => {
+      stopTimer();
+      if (document.visibilityState !== "visible") return;
+
+      const now = new Date();
+      timeoutId = setTimeout(() => {
+        timeoutId = undefined;
+        setSelectedDateTimeState(startOfMinute(new Date()));
+        scheduleNextMinute();
+      }, millisecondsUntilNextMinute(now));
+    };
+
+    const catchUpToNow = () => {
+      if (document.visibilityState === "visible") {
+        setSelectedDateTimeState(startOfMinute(new Date()));
+        scheduleNextMinute();
+      } else {
+        stopTimer();
+      }
+    };
+
+    if (document.visibilityState === "visible") {
+      scheduleNextMinute();
+    }
+    document.addEventListener("visibilitychange", catchUpToNow);
+    window.addEventListener("focus", catchUpToNow);
+
+    return () => {
+      stopTimer();
+      document.removeEventListener("visibilitychange", catchUpToNow);
+      window.removeEventListener("focus", catchUpToNow);
+    };
+  }, [isLive]);
 
   // Format the date as YYYY-MM-DD for API calls
   const formattedDate = moment(selectedDateTime).format("YYYY-MM-DD");
   
   // Format the time as HH:mm:ss for API calls
   const formattedTime = moment(selectedDateTime).format("HH:mm:ss");
-
-  // Check if the selected date/time is the current date/time (within 1 minute)
-  const isCurrentDateTime = () => {
-    const now = new Date();
-    const diffMs = Math.abs(selectedDateTime.getTime() - now.getTime());
-    const diffMinutes = diffMs / (1000 * 60);
-    return diffMinutes < 1;
-  };
-
-  // Reset to current date/time
-  const resetToCurrentDateTime = () => {
-    setSelectedDateTime(new Date());
-  };
 
   return (
     <DateTimeContext.Provider
@@ -41,7 +106,7 @@ export function DateTimeProvider({ children }: { children: ReactNode }) {
         setSelectedDateTime,
         formattedDate,
         formattedTime,
-        isCurrentDateTime: isCurrentDateTime(),
+        isCurrentDateTime: isLive,
         resetToCurrentDateTime,
       }}
     >

--- a/src/contexts/DateTimeContext.tsx
+++ b/src/contexts/DateTimeContext.tsx
@@ -39,7 +39,7 @@ export function DateTimeProvider({ children }: { children: ReactNode }) {
 
   const setSelectedDateTime = useCallback((date: Date) => {
     setIsLive(false);
-    setSelectedDateTimeState(date);
+    setSelectedDateTimeState(startOfMinute(date));
   }, []);
 
   const resetToCurrentDateTime = useCallback(() => {

--- a/src/utils/liveUpdates.test.ts
+++ b/src/utils/liveUpdates.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { FacilityStatus, FacilityType, RoomStatus } from "@/types";
-import { ageLiveAvailability } from "./liveUpdates";
+import {
+  ageLiveAvailability,
+  shouldRefetchFacilitiesOnReconnect,
+} from "./liveUpdates";
 
 function academicData(overrides: Partial<FacilityStatus> = {}): FacilityStatus {
   return {
@@ -58,5 +61,16 @@ describe("ageLiveAvailability", () => {
     expect(aged?.facilities.dcl.rooms["1320"].availableFor).toBe(43);
     expect(aged?.facilities.dcl.rooms.future.availableFor).toBe(30);
     expect(data.facilities.dcl.rooms["1320"].availableFor).toBe(50);
+  });
+});
+
+describe("shouldRefetchFacilitiesOnReconnect", () => {
+  it("does not refetch stale live data when a hidden tab comes online", () => {
+    expect(shouldRefetchFacilitiesOnReconnect(true, "hidden")).toBe(false);
+  });
+
+  it("allows visible live data and fixed-time data to refetch", () => {
+    expect(shouldRefetchFacilitiesOnReconnect(true, "visible")).toBe(true);
+    expect(shouldRefetchFacilitiesOnReconnect(false, "hidden")).toBe(true);
   });
 });

--- a/src/utils/liveUpdates.test.ts
+++ b/src/utils/liveUpdates.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { FacilityStatus, FacilityType, RoomStatus } from "@/types";
+import { ageLiveAvailability } from "./liveUpdates";
+
+function academicData(overrides: Partial<FacilityStatus> = {}): FacilityStatus {
+  return {
+    timestamp: "2026-08-24T09:00:00-05:00",
+    facilities: {
+      dcl: {
+        id: "dcl",
+        name: "Digital Computer Laboratory",
+        type: FacilityType.ACADEMIC,
+        coordinates: { latitude: 0, longitude: 0 },
+        hours: { open: "08:00", close: "22:00" },
+        isOpen: true,
+        roomCounts: { available: 0, total: 1 },
+        rooms: {
+          "1320": {
+            type: "academic",
+            status: RoomStatus.OCCUPIED,
+            currentClass: {
+              course: "CS 101",
+              title: "Intro",
+              time: { start: "09:00:00", end: "09:50:00" },
+            },
+            nextClass: {
+              course: "CS 102",
+              title: "Next",
+              time: { start: "10:00:00", end: "10:50:00" },
+            },
+            availableAt: "09:50:00",
+          },
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("ageLiveAvailability", () => {
+  it("counts down current availability without changing future windows", () => {
+    const data = academicData();
+    const room = data.facilities.dcl.rooms["1320"];
+    room.status = RoomStatus.AVAILABLE;
+    room.availableFor = 50;
+    data.facilities.dcl.rooms.future = {
+      type: "academic",
+      status: RoomStatus.OCCUPIED,
+      availableAt: "10:00:00",
+      availableFor: 30,
+    };
+
+    const aged = ageLiveAvailability(
+      data,
+      new Date("2026-08-24T09:07:00-05:00"),
+    );
+
+    expect(aged?.facilities.dcl.rooms["1320"].availableFor).toBe(43);
+    expect(aged?.facilities.dcl.rooms.future.availableFor).toBe(30);
+    expect(data.facilities.dcl.rooms["1320"].availableFor).toBe(50);
+  });
+});

--- a/src/utils/liveUpdates.ts
+++ b/src/utils/liveUpdates.ts
@@ -1,0 +1,51 @@
+import { FacilityStatus, RoomStatus } from "@/types";
+
+export const LIVE_REFRESH_INTERVAL_MS = 5 * 60_000;
+
+export function ageLiveAvailability(
+  data: FacilityStatus | undefined,
+  now: Date,
+): FacilityStatus | undefined {
+  if (!data) return undefined;
+
+  const timestamp = Date.parse(data.timestamp);
+  if (!Number.isFinite(timestamp)) return data;
+
+  const elapsedMinutes = Math.max(
+    0,
+    Math.floor((now.getTime() - timestamp) / 60_000),
+  );
+  if (elapsedMinutes === 0) return data;
+
+  return {
+    ...data,
+    facilities: Object.fromEntries(
+      Object.entries(data.facilities).map(([facilityId, facility]) => [
+        facilityId,
+        {
+          ...facility,
+          rooms: Object.fromEntries(
+            Object.entries(facility.rooms).map(([roomId, room]) => {
+              const isCurrentlyAvailable =
+                room.status === RoomStatus.AVAILABLE ||
+                room.status === RoomStatus.PASSING_PERIOD;
+
+              return [
+                roomId,
+                isCurrentlyAvailable && room.availableFor !== undefined
+                  ? {
+                      ...room,
+                      availableFor: Math.max(
+                        0,
+                        room.availableFor - elapsedMinutes,
+                      ),
+                    }
+                  : room,
+              ];
+            }),
+          ),
+        },
+      ]),
+    ),
+  };
+}

--- a/src/utils/liveUpdates.ts
+++ b/src/utils/liveUpdates.ts
@@ -2,6 +2,13 @@ import { FacilityStatus, RoomStatus } from "@/types";
 
 export const LIVE_REFRESH_INTERVAL_MS = 5 * 60_000;
 
+export function shouldRefetchFacilitiesOnReconnect(
+  isLive: boolean,
+  visibilityState: DocumentVisibilityState = document.visibilityState,
+): boolean {
+  return !isLive || visibilityState === "visible";
+}
+
 export function ageLiveAvailability(
   data: FacilityStatus | undefined,
   now: Date,


### PR DESCRIPTION
IlliniSpots now keeps "Now" mode current without issuing requests every minute. Visible tabs refresh academic and library facility data every five minutes, refresh immediately after returning from the background, and stop network refreshes while hidden. Availability durations continue counting down locally on minute boundaries.

Selecting a custom date and time pauses live behavior until the user explicitly returns to "Now." This keeps historical and future views stable. The five-minute cadence intentionally allows network-backed room status to be up to five minutes old in exchange for substantially lower request volume.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live facility availability updates when viewing the current date and time.
  - Availability refreshes automatically while the page is visible.
  - Added a “Reset to now” option in the date and time picker.
  - Manual date and time selections pause live updates; resetting to now resumes them.
  - Staging deployments now maintain at least one running instance.
- **Tests**
  - Added coverage for live time handling and availability calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->