### PR TITLE
ref(ui): consolidate time filter into free until

### DIFF
--- a/src/components/RoomFilter.tsx
+++ b/src/components/RoomFilter.tsx
@@ -12,8 +12,8 @@ import {
     DrawerTrigger,
 } from "@/components/ui/drawer";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import { ListFilter, Hourglass, Clock } from "lucide-react";
-import { getCampusDateTimeParts, formatTimeForDisplay } from "@/utils/time";
+import { ListFilter, Clock } from "lucide-react";
+import { getCampusDateTimeParts } from "@/utils/time";
 
 const PRESET_DURATIONS = [30, 60, 120, 240] as const;
 const MIN_CUSTOM_DURATION = 1;
@@ -23,8 +23,6 @@ interface RoomFilterPopoverProps {
     setMinDuration: (value: number | undefined) => void;
     freeUntil: string;
     setFreeUntil: (value: string) => void;
-    startTime: string;
-    setStartTime: (value: string) => void;
     hasActiveFilters: boolean;
     onClearAll: () => void;
     matchingRoomsCount: number;
@@ -35,8 +33,6 @@ const RoomFilterPopover: React.FC<RoomFilterPopoverProps> = ({
     setMinDuration,
     freeUntil,
     setFreeUntil,
-    startTime,
-    setStartTime,
     hasActiveFilters,
     onClearAll,
     matchingRoomsCount,
@@ -141,14 +137,14 @@ const RoomFilterPopover: React.FC<RoomFilterPopoverProps> = ({
                     <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2 text-sm font-medium text-foreground/80">
                             <Clock size={14} className="text-muted-foreground" />
-                            Start Time
+                            Free Until
                         </div>
-                        {startTime && (
+                        {freeUntil && (
                             <Button
                                 variant="ghost"
                                 size="sm"
                                 className="h-5 px-1 text-xs text-muted-foreground hover:text-foreground hover:bg-transparent underline"
-                                onClick={() => setStartTime("")}
+                                onClick={() => setFreeUntil("")}
                             >
                                 Clear
                             </Button>
@@ -157,22 +153,19 @@ const RoomFilterPopover: React.FC<RoomFilterPopoverProps> = ({
                     <div className="relative">
                         <Input
                             type="time"
-                            value={startTime}
-                            onChange={(e) => setStartTime(e.target.value)}
+                            value={freeUntil}
+                            onChange={(e) => setFreeUntil(e.target.value)}
                             onFocus={() => {
-                                if (!startTime) {
-                                    const campusNow = getCampusDateTimeParts();
-                                    setStartTime(campusNow.time.slice(0, 5));
+                                if (!freeUntil) {
+                                     const campusNow = getCampusDateTimeParts();
+                                    setFreeUntil(campusNow.time.slice(0, 5));
                                 }
                             }}
                             className="h-9 pl-9 pr-3 font-mono text-sm appearance-none [&::-webkit-date-and-time-value]:text-left [&::-webkit-date-and-time-value]:min-h-0 [&::-webkit-calendar-picker-indicator]:hidden"
-                            placeholder="When room must be free"
+                            placeholder="Custom time"
                         />
                         <Clock className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
                     </div>
-                    <p className="text-[10px] text-muted-foreground pl-1">
-                        Find rooms that are available by this time.
-                    </p>
                 </div>
 
                 <div className="space-y-3">
@@ -245,64 +238,6 @@ const RoomFilterPopover: React.FC<RoomFilterPopoverProps> = ({
                             )}
                         </div>
                     )}
-                </div>
-
-                <div className="space-y-3">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2 text-sm font-medium text-foreground/80">
-                            <Hourglass size={14} className="text-muted-foreground" />
-                            Free Until
-                        </div>
-                        {freeUntil && (
-                            <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-5 px-1 text-xs text-muted-foreground hover:text-foreground hover:bg-transparent underline"
-                                onClick={() => setFreeUntil("")}
-                            >
-                                Clear
-                            </Button>
-                        )}
-                    </div>
-                    <div className="space-y-2">
-                        <div className="grid grid-cols-3 gap-2">
-                            {["12:00", "15:00", "18:00"].map((time) => (
-                                <Button
-                                    key={time}
-                                    variant={freeUntil === time ? "default" : "outline"}
-                                    size="sm"
-                                    onClick={() =>
-                                        setFreeUntil(freeUntil === time ? "" : time)
-                                    }
-                                    className={`h-8 text-xs font-medium transition-all ${freeUntil === time
-                                        ? "shadow-sm"
-                                        : "hover:border-primary/50 hover:bg-primary/5"
-                                        }`}
-                                >
-                                    {formatTimeForDisplay(time)}
-                                </Button>
-                            ))}
-                        </div>
-                        <div className="relative">
-                            <Input
-                                type="time"
-                                value={freeUntil}
-                                onChange={(e) => setFreeUntil(e.target.value)}
-                                onFocus={() => {
-                                    if (!freeUntil) {
-                                        const campusNow = getCampusDateTimeParts();
-                                        setFreeUntil(campusNow.time.slice(0, 5));
-                                    }
-                                }}
-                                className="h-9 pl-9 pr-3 font-mono text-sm appearance-none [&::-webkit-date-and-time-value]:text-left [&::-webkit-date-and-time-value]:min-h-0 [&::-webkit-calendar-picker-indicator]:hidden"
-                                placeholder="Custom time"
-                            />
-                            <Clock className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-                        </div>
-                    </div>
-                    <p className="text-[10px] text-muted-foreground pl-1">
-                        Find rooms available at least until this time today.
-                    </p>
                 </div>
             </div>
         </div>

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -114,19 +114,17 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     const { selectedDateTime, isCurrentDateTime, resetToCurrentDateTime } = useDateTimeContext();
     const [minDuration, setMinDuration] = useState<number | undefined>(undefined);
     const [freeUntil, setFreeUntil] = useState<string>("");
-    const [startTime, setStartTime] = useState<string>("");
 
     const filterCriteria: FilterCriteria = useMemo(
         () => ({
             minDuration,
             freeUntil: freeUntil || undefined,
-            startTime: startTime || undefined,
             nowMinutes: parseTimeToMinutes(selectedDateTime.time) ?? undefined,
         }),
-        [minDuration, freeUntil, startTime, selectedDateTime],
+        [minDuration, freeUntil, selectedDateTime],
     );
 
-    const hasActiveFilters = !!minDuration || !!freeUntil || !!startTime;
+    const hasActiveFilters = !!minDuration || !!freeUntil;
     const isSearching = searchTerm.trim().length > 0;
 
     const scrollToAccordion = useCallback((accordionId: string) => {
@@ -226,7 +224,6 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     const clearFilters = () => {
         setMinDuration(undefined);
         setFreeUntil("");
-        setStartTime("");
     };
 
     const [isFavoritesDialogOpen, setIsFavoritesDialogOpen] = useState(false);
@@ -268,8 +265,6 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                             setMinDuration={setMinDuration}
                             freeUntil={freeUntil}
                             setFreeUntil={setFreeUntil}
-                            startTime={startTime}
-                            setStartTime={setStartTime}
                             hasActiveFilters={hasActiveFilters}
                             onClearAll={clearFilters}
                             matchingRoomsCount={matchingRoomsCount}

--- a/src/utils/filterUtils.test.ts
+++ b/src/utils/filterUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { isRoomAvailable } from "@/utils/filterUtils";
+import { AcademicRoom, FacilityRoom, RoomStatus } from "@/types";
+
+const createRoom = (overrides: Partial<AcademicRoom> = {}): FacilityRoom => ({
+  type: "academic",
+  status: RoomStatus.AVAILABLE,
+  availableFor: 120,
+  passingPeriod: false,
+  ...overrides,
+});
+
+describe("isRoomAvailable", () => {
+  test("returns true when no criteria specified", () => {
+    const room = createRoom();
+    expect(isRoomAvailable(room, {})).toBe(true);
+  });
+
+  test("rejects unavailable or occupied rooms", () => {
+    const room = createRoom({ status: RoomStatus.OCCUPIED });
+    expect(isRoomAvailable(room, { minDuration: 30 })).toBe(false);
+  });
+
+  test("allows passing period rooms if duration matches", () => {
+    const room = createRoom({ status: RoomStatus.PASSING_PERIOD, availableFor: 60 });
+    expect(isRoomAvailable(room, { minDuration: 30 })).toBe(true);
+    expect(isRoomAvailable(room, { minDuration: 90 })).toBe(false);
+  });
+
+  test("filters by minDuration", () => {
+    const room = createRoom({ availableFor: 45 });
+    expect(isRoomAvailable(room, { minDuration: 30 })).toBe(true);
+    expect(isRoomAvailable(room, { minDuration: 45 })).toBe(true);
+    expect(isRoomAvailable(room, { minDuration: 60 })).toBe(false);
+  });
+
+  test("filters by freeUntil time", () => {
+    // Current time 14:00 (840 min), available for 120 min (until 16:00)
+    const room = createRoom({ availableFor: 120 });
+    const nowMinutes = 14 * 60; // 840
+
+    // Free until 15:30 (90 min from now) -> valid
+    expect(isRoomAvailable(room, { freeUntil: "15:30", nowMinutes })).toBe(true);
+
+    // Free until 16:00 (120 min from now) -> valid
+    expect(isRoomAvailable(room, { freeUntil: "16:00", nowMinutes })).toBe(true);
+
+    // Free until 16:30 (150 min from now) -> invalid (only available 120 min)
+    expect(isRoomAvailable(room, { freeUntil: "16:30", nowMinutes })).toBe(false);
+
+    // Past time 13:00 -> invalid
+    expect(isRoomAvailable(room, { freeUntil: "13:00", nowMinutes })).toBe(false);
+  });
+
+  test("combines minDuration and freeUntil", () => {
+    const room = createRoom({ availableFor: 120 });
+    const nowMinutes = 14 * 60;
+
+    // Needs 60 min and free until 15:30 (90 min) -> passes both
+    expect(isRoomAvailable(room, { minDuration: 60, freeUntil: "15:30", nowMinutes })).toBe(true);
+
+    // Needs 150 min and free until 15:30 -> fails minDuration
+    expect(isRoomAvailable(room, { minDuration: 150, freeUntil: "15:30", nowMinutes })).toBe(false);
+  });
+});

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -4,7 +4,6 @@ import { getCampusDateTimeParts, parseTimeToMinutes } from "@/utils/time";
 export interface FilterCriteria {
   minDuration?: number;
   freeUntil?: string;
-  startTime?: string;
   nowMinutes?: number;
 }
 
@@ -12,7 +11,7 @@ export const isRoomAvailable = (
   room: FacilityRoom,
   criteria: FilterCriteria,
 ): boolean => {
-  if (!criteria.minDuration && !criteria.freeUntil && !criteria.startTime) {
+  if (!criteria.minDuration && !criteria.freeUntil) {
     return true;
   }
 
@@ -28,21 +27,6 @@ export const isRoomAvailable = (
   const nowMinutes =
     criteria.nowMinutes ?? campusNow.hour * 60 + campusNow.minute;
 
-  if (criteria.startTime) {
-    const startMinutes = parseTimeToMinutes(criteria.startTime);
-    if (
-      startMinutes === null ||
-      startMinutes < nowMinutes ||
-      availableFor < startMinutes - nowMinutes
-    ) {
-      return false;
-    }
-  }
-
-  if (criteria.minDuration && availableFor < criteria.minDuration) {
-    return false;
-  }
-
   if (criteria.freeUntil) {
     const targetMinutes = parseTimeToMinutes(criteria.freeUntil);
     if (
@@ -52,6 +36,10 @@ export const isRoomAvailable = (
     ) {
       return false;
     }
+  }
+
+  if (criteria.minDuration && availableFor < criteria.minDuration) {
+    return false;
   }
 
   return true;


### PR DESCRIPTION
In order to prevent confusion between room search filters and the global time picker, this PR consolidates duplicate time filtering into a single Free Until input, removes redundant narrative copy, and adds unit test coverage for availability filtering.

### Before
The room filter popover contained both "Start Time" and "Free Until" controls executing the same continuous-availability calculation (`availableFor >= target - now`). Labeling continuous availability as "Start Time" contradicted the filter behavior and overlapped with the global header date/time picker.

### After
- Removed the redundant "Start Time" filter option across UI and state.
- Retained "Free Until" using a single time input without narrative helper text.
- Added unit test suite covering `isRoomAvailable` criteria combinations and bounds.

### Change type
- [x] `improvement`

### Test plan
- [x] Unit tests (`bun test src/utils/filterUtils.test.ts`)
- [x] Lint and typecheck (`bun run lint && bun run typecheck`)

### Release notes
- Consolidate room availability time filtering into Free Until and simplify filter UI.

### Code changes
| Section   | LOC change |
| --------- | ---------- |
| Core code | +18 / -100 |
| Tests     | +65 / -0   |