### PR TITLE
feat(search): add natural language date queries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@supabase/supabase-js": "^2.45.6",
         "@tanstack/react-query": "^5.71.1",
         "@tanstack/react-router": "^1.170.31",
+        "chrono-node": "^2.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "hono": "^4.13.3",
@@ -488,6 +489,8 @@
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "chrono-node": ["chrono-node@2.10.1", "", {}, "sha512-tPOsBzYVAK5zth+CiHCgp5NGeqRc4mMD8FPthQ5IxkgjPWWxIFdM5odnmfw//IRAzl6C++Xy8olQW7wn5qBR1g=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.1", "", {}, "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@supabase/supabase-js": "^2.45.6",
     "@tanstack/react-query": "^5.71.1",
     "@tanstack/react-router": "^1.170.31",
+    "chrono-node": "^2.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "hono": "^4.13.3",

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -43,7 +43,18 @@ import { useFavorites } from "@/hooks/useFavorites";
 import { isRoomAvailable, FilterCriteria } from "@/utils/filterUtils";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
 import { ThemeToggle } from "@/components/ThemeToggle";
-import { parseTimeToMinutes, formatDateForDisplay, formatTimeForDisplay, getCampusDateTimeParts } from "@/utils/time";
+import {
+    CAMPUS_TIMEZONE,
+    parseTimeToMinutes,
+    formatDateForDisplay,
+    formatTimeForDisplay,
+    getCampusDateTimeParts,
+} from "@/utils/time";
+import {
+    parseNaturalLanguageSearch,
+    type NaturalLanguageSearchResult,
+} from "@/utils/naturalLanguageSearch";
+import { DateTime } from "luxon";
 
 interface LeftSidebarProps {
     facilityData: FacilityStatus | null;
@@ -93,6 +104,58 @@ const ActiveTimeBanner: React.FC<ActiveTimeBannerProps> = ({
     );
 };
 
+interface NaturalSearchPromptProps {
+    interpretation: NaturalLanguageSearchResult;
+    onApply: () => void;
+}
+
+const NaturalSearchPrompt: React.FC<NaturalSearchPromptProps> = ({
+    interpretation,
+    onApply,
+}) => {
+    const errorMessage =
+        interpretation.error === "ambiguous-time"
+            ? "Add AM or PM so we know which time you mean."
+            : interpretation.error === "multiple-date-times"
+                ? "Use one date and time in each search."
+                : null;
+    const target = interpretation.dateTime;
+
+    return (
+        <div className="px-4 py-8 flex justify-center">
+            <div className="w-full max-w-sm rounded-lg border bg-card p-4 space-y-3 text-center">
+                <CalendarClock className="h-6 w-6 mx-auto text-primary" />
+                {errorMessage ? (
+                    <>
+                        <p className="text-sm font-medium">Clarify your search</p>
+                        <p className="text-xs text-muted-foreground">{errorMessage}</p>
+                    </>
+                ) : target ? (
+                    <>
+                        <div className="space-y-1">
+                            <p className="text-sm font-medium">
+                                {interpretation.locationQuery
+                                    ? `Search ${interpretation.locationQuery}`
+                                    : "View all spots"}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                                {formatDateForDisplay(target.date)} at{" "}
+                                {formatTimeForDisplay(target.time)}
+                            </p>
+                        </div>
+                        <Button size="sm" onClick={onApply} className="h-8 text-xs">
+                            Search this time
+                        </Button>
+                        <p className="text-[11px] text-muted-foreground">
+                            Press Enter to apply
+                        </p>
+                    </>
+                ) : null}
+            </div>
+        </div>
+    );
+};
+
 
 
 const LeftSidebar: React.FC<LeftSidebarProps> = ({
@@ -111,7 +174,12 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     const scrollAreaRef = useRef<HTMLDivElement | null>(null);
     const [searchTerm, setSearchTerm] = useState("");
     const { favorites, toggleFavorite } = useFavorites();
-    const { selectedDateTime, isCurrentDateTime, resetToCurrentDateTime } = useDateTimeContext();
+    const {
+        selectedDateTime,
+        setSelectedDateTime,
+        isCurrentDateTime,
+        resetToCurrentDateTime,
+    } = useDateTimeContext();
     const [minDuration, setMinDuration] = useState<number | undefined>(undefined);
     const [freeUntil, setFreeUntil] = useState<string>("");
 
@@ -126,6 +194,39 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
 
     const hasActiveFilters = !!minDuration || !!freeUntil;
     const isSearching = searchTerm.trim().length > 0;
+    const naturalSearch = useMemo(
+        () => parseNaturalLanguageSearch(searchTerm),
+        [searchTerm],
+    );
+    const hasTemporalSearch = naturalSearch.temporalText !== null;
+
+    const applyNaturalSearch = useCallback(() => {
+        if (naturalSearch.error || !naturalSearch.dateTime) return;
+
+        setSelectedDateTime(naturalSearch.dateTime);
+        setSearchTerm(naturalSearch.locationQuery);
+    }, [naturalSearch, setSelectedDateTime]);
+
+    const handleSearchSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        applyNaturalSearch();
+    };
+
+    const facilityDataMatchesSelection = useMemo(() => {
+        if (!facilityData || isCurrentDateTime) return true;
+
+        const responseDateTime = DateTime.fromISO(facilityData.timestamp).setZone(
+            CAMPUS_TIMEZONE,
+        );
+        if (!responseDateTime.isValid) return false;
+
+        return (
+            responseDateTime.toFormat("yyyy-MM-dd") === selectedDateTime.date &&
+            responseDateTime.toFormat("HH:mm") === selectedDateTime.time.slice(0, 5)
+        );
+    }, [facilityData, isCurrentDateTime, selectedDateTime]);
+
+    const searchFacilityData = facilityDataMatchesSelection ? facilityData : null;
 
     const scrollToAccordion = useCallback((accordionId: string) => {
         const element = accordionRefs.current[accordionId];
@@ -237,7 +338,10 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                 </h1>
                 <TooltipProvider delayDuration={50}>
                     <div className="flex-1 min-w-0 flex gap-2 items-center">
-                        <div className="relative flex-1 min-w-[70px]">
+                        <form
+                            className="relative flex-1 min-w-[70px]"
+                            onSubmit={handleSearchSubmit}
+                        >
                             <Search
                                 className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
                                 aria-hidden="true"
@@ -246,12 +350,13 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                 type="text"
                                 value={searchTerm}
                                 onChange={(e) => setSearchTerm(e.target.value)}
-                                placeholder="Search buildings & rooms..."
+                                placeholder="Try ECEB tomorrow at 2:30 pm"
                                 className={`pl-8 ${searchTerm ? "pr-8" : ""} h-9 md:h-9 rounded-full text-sm`}
-                                aria-label="Search buildings and rooms"
+                                aria-label="Search buildings, rooms, dates, and times"
                             />
                             {searchTerm && (
                                 <button
+                                    type="button"
                                     onClick={() => setSearchTerm("")}
                                     className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
                                     aria-label="Clear search"
@@ -259,7 +364,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                     <X size={14} />
                                 </button>
                             )}
-                        </div>
+                        </form>
                         <RoomFilter
                             minDuration={minDuration}
                             setMinDuration={setMinDuration}
@@ -393,15 +498,22 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                 viewportClassName="[&>div]:!block [&>div]:!min-w-0"
                 ref={scrollAreaRef}
             >
-                {isSearching ? (
+                {isSearching && hasTemporalSearch ? (
+                    <NaturalSearchPrompt
+                        interpretation={naturalSearch}
+                        onApply={applyNaturalSearch}
+                    />
+                ) : isSearching ? (
                     <SearchResults
-                        facilityData={facilityData}
+                        facilityData={searchFacilityData}
                         searchTerm={searchTerm}
                         filterCriteria={filterCriteria}
                         hasActiveFilters={hasActiveFilters}
                         onClearFilters={clearFilters}
                         onClearSearch={() => setSearchTerm("")}
-                        isLoading={isAcademicLoading}
+                        isLoading={
+                            isAcademicLoading || isFetching || !facilityDataMatchesSelection
+                        }
                         isLibraryLoading={isLibraryFetching}
                     />
                 ) : (

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -350,7 +350,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                 type="text"
                                 value={searchTerm}
                                 onChange={(e) => setSearchTerm(e.target.value)}
-                                placeholder="Try ECEB tomorrow at 2:30 pm"
+                                placeholder="Try CIF tmrw 2pm"
                                 className={`pl-8 ${searchTerm ? "pr-8" : ""} h-9 md:h-9 rounded-full text-sm`}
                                 aria-label="Search buildings, rooms, dates, and times"
                             />

--- a/src/utils/naturalLanguageSearch.test.ts
+++ b/src/utils/naturalLanguageSearch.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { parseNaturalLanguageSearch } from "@/utils/naturalLanguageSearch";
+
+const WEDNESDAY_NOON_CAMPUS = new Date("2026-08-26T17:00:00.000Z");
+
+describe("parseNaturalLanguageSearch", () => {
+  test("leaves ordinary building and room searches unchanged", () => {
+    expect(
+      parseNaturalLanguageSearch("eceb 1102", WEDNESDAY_NOON_CAMPUS),
+    ).toEqual({
+      locationQuery: "eceb 1102",
+      temporalText: null,
+      dateTime: null,
+      error: null,
+    });
+  });
+
+  test("parses a relative duration from campus time", () => {
+    expect(
+      parseNaturalLanguageSearch(
+        "siebel in 2 hours",
+        WEDNESDAY_NOON_CAMPUS,
+      ),
+    ).toEqual({
+      locationQuery: "siebel",
+      temporalText: "in 2 hours",
+      dateTime: { date: "2026-08-26", time: "14:00:00" },
+      error: null,
+    });
+  });
+
+  test("parses tomorrow with an explicit time", () => {
+    expect(
+      parseNaturalLanguageSearch(
+        "eceb tomorrow at 2:30 pm",
+        WEDNESDAY_NOON_CAMPUS,
+      ),
+    ).toEqual({
+      locationQuery: "eceb",
+      temporalText: "tomorrow at 2:30 pm",
+      dateTime: { date: "2026-08-27", time: "14:30:00" },
+      error: null,
+    });
+  });
+
+  test("uses the upcoming weekday and preserves the room number", () => {
+    expect(
+      parseNaturalLanguageSearch(
+        "eceb 1102 friday at 11 am",
+        WEDNESDAY_NOON_CAMPUS,
+      ),
+    ).toEqual({
+      locationQuery: "eceb 1102",
+      temporalText: "friday at 11 am",
+      dateTime: { date: "2026-08-28", time: "11:00:00" },
+      error: null,
+    });
+  });
+
+  test("uses the current campus time when only a date is provided", () => {
+    const reference = new Date("2026-08-26T17:42:35.000Z");
+    expect(parseNaturalLanguageSearch("dcl tomorrow", reference).dateTime).toEqual(
+      { date: "2026-08-27", time: "12:42:00" },
+    );
+  });
+
+  test("rejects ambiguous twelve-hour times", () => {
+    expect(
+      parseNaturalLanguageSearch("eceb tomorrow at 2", WEDNESDAY_NOON_CAMPUS),
+    ).toMatchObject({
+      locationQuery: "eceb",
+      temporalText: "tomorrow at 2",
+      dateTime: null,
+      error: "ambiguous-time",
+    });
+  });
+
+  test("allows a date and time without a building or room", () => {
+    expect(
+      parseNaturalLanguageSearch("tomorrow at 2 pm", WEDNESDAY_NOON_CAMPUS),
+    ).toEqual({
+      locationQuery: "",
+      temporalText: "tomorrow at 2 pm",
+      dateTime: { date: "2026-08-27", time: "14:00:00" },
+      error: null,
+    });
+  });
+
+  test("preserves elapsed relative time across the spring DST transition", () => {
+    const beforeSpringForward = new Date("2026-03-08T07:30:00.000Z");
+    expect(
+      parseNaturalLanguageSearch(
+        "siebel in 2 hours",
+        beforeSpringForward,
+      ).dateTime,
+    ).toEqual({ date: "2026-03-08", time: "04:30:00" });
+  });
+});

--- a/src/utils/naturalLanguageSearch.ts
+++ b/src/utils/naturalLanguageSearch.ts
@@ -1,0 +1,142 @@
+import * as chrono from "chrono-node/en";
+import { DateTime } from "luxon";
+import {
+  CAMPUS_TIMEZONE,
+  type CampusDateTime,
+} from "@/utils/time";
+
+export type NaturalLanguageSearchError =
+  | "ambiguous-time"
+  | "multiple-date-times";
+
+export interface NaturalLanguageSearchResult {
+  locationQuery: string;
+  temporalText: string | null;
+  dateTime: CampusDateTime | null;
+  error: NaturalLanguageSearchError | null;
+}
+
+function removeMatchedText(
+  query: string,
+  matches: Array<{ index: number; text: string }>,
+): string {
+  let locationQuery = query;
+
+  for (const match of [...matches].sort((a, b) => b.index - a.index)) {
+    locationQuery =
+      locationQuery.slice(0, match.index) +
+      locationQuery.slice(match.index + match.text.length);
+  }
+
+  return locationQuery
+    .replace(/^[\s,;|-]+|[\s,;|-]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function parseNaturalLanguageSearch(
+  query: string,
+  referenceInstant: Date = new Date(),
+): NaturalLanguageSearchResult {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) {
+    return {
+      locationQuery: "",
+      temporalText: null,
+      dateTime: null,
+      error: null,
+    };
+  }
+
+  const campusReference = DateTime.fromJSDate(referenceInstant).setZone(
+    CAMPUS_TIMEZONE,
+  );
+  const matches = chrono.parse(
+    normalizedQuery,
+    {
+      instant: referenceInstant,
+      timezone: campusReference.offset,
+    },
+    { forwardDate: true },
+  );
+
+  if (matches.length === 0) {
+    return {
+      locationQuery: normalizedQuery,
+      temporalText: null,
+      dateTime: null,
+      error: null,
+    };
+  }
+
+  const locationQuery = removeMatchedText(normalizedQuery, matches);
+  const temporalText = matches.map((match) => match.text).join(", ");
+
+  if (matches.length > 1) {
+    return {
+      locationQuery,
+      temporalText,
+      dateTime: null,
+      error: "multiple-date-times",
+    };
+  }
+
+  const match = matches[0];
+  const hasExplicitHour = match.start.isCertain("hour");
+  const hour = match.start.get("hour");
+  if (
+    hasExplicitHour &&
+    hour !== null &&
+    hour >= 1 &&
+    hour <= 12 &&
+    !match.start.isCertain("meridiem")
+  ) {
+    return {
+      locationQuery,
+      temporalText,
+      dateTime: null,
+      error: "ambiguous-time",
+    };
+  }
+
+  let target: DateTime;
+  if (match.start.isCertain("timezoneOffset")) {
+    // Rebuilding relative durations from wall-clock parts loses time at DST boundaries.
+    target = DateTime.fromJSDate(match.start.date()).setZone(CAMPUS_TIMEZONE);
+  } else {
+    target = DateTime.fromObject(
+      {
+        year: match.start.get("year") ?? campusReference.year,
+        month: match.start.get("month") ?? campusReference.month,
+        day: match.start.get("day") ?? campusReference.day,
+        hour: hasExplicitHour
+          ? (match.start.get("hour") ?? campusReference.hour)
+          : campusReference.hour,
+        minute: hasExplicitHour
+          ? (match.start.get("minute") ?? 0)
+          : campusReference.minute,
+        second: 0,
+      },
+      { zone: CAMPUS_TIMEZONE },
+    );
+  }
+
+  if (!target.isValid) {
+    return {
+      locationQuery,
+      temporalText,
+      dateTime: null,
+      error: "multiple-date-times",
+    };
+  }
+
+  return {
+    locationQuery,
+    temporalText,
+    dateTime: {
+      date: target.toFormat("yyyy-MM-dd"),
+      time: target.startOf("minute").toFormat("HH:mm:ss"),
+    },
+    error: null,
+  };
+}


### PR DESCRIPTION
In order to let students search for availability at a future time without opening the date picker, this PR extracts natural-language dates and times from building and room searches. Chrono recognizes phrases such as “in 2 hours,” “tomorrow at 2:30 pm,” and “Friday at 11 am,” while Luxon normalizes the result to `America/Chicago`. Temporal searches require confirmation before fetching, ambiguous twelve-hour times ask for AM or PM, and time-only queries show all facilities at the requested time.

### Change type

- [x] `feature`

### Test plan

1. Search for `siebel in 2 hours`, apply the interpretation, and verify the selected-time banner and Siebel results.
2. Search for `eceb tomorrow at 2:30 pm` and `eceb 1102 friday at 11 am`, then verify the interpreted date, time, building, and room.
3. Search for `tomorrow at 2 pm` and verify all facilities appear at that time.
4. Search for `eceb tomorrow at 2` and verify the UI requests AM or PM.
5. Verify the deployed behavior at https://staging.illinispots.com/.

- [x] Unit tests

### Release notes

- Add natural-language date and time phrases to building and room search.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +142 / -0  |
| Tests          | +98 / -0   |
| Apps           | +121 / -9  |
| Config/tooling | +4 / -0    |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added natural-language date and time search support.
  * Search can interpret locations, rooms, relative times, weekdays, and explicit dates.
  * Results are matched using campus-local date and time.
  * Added clear messages for ambiguous or conflicting date and time requests.
  * Updated search controls and accessibility labels for easier use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->