### PR TITLE
perf(client): remove Luxon from client bundle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "illinispots",
       "dependencies": {
+        "@date-fns/tz": "^1.5.0",
         "@fontsource-variable/inter": "^5.3.0",
         "@leeoniya/ufuzzy": "^1.0.19",
         "@radix-ui/react-accordion": "^1.2.1",
@@ -25,6 +26,7 @@
         "chrono-node": "^2.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.4.0",
         "hono": "^4.13.3",
         "lucide-react": "^0.454.0",
         "luxon": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "check": "bun run lint && bun run test && bun run build"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.5.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@leeoniya/ufuzzy": "^1.0.19",
     "@radix-ui/react-accordion": "^1.2.1",
@@ -40,6 +41,7 @@
     "chrono-node": "^2.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.4.0",
     "hono": "^4.13.3",
     "lucide-react": "^0.454.0",
     "luxon": "^3.7.2",

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -44,7 +44,6 @@ import { isRoomAvailable, FilterCriteria } from "@/utils/filterUtils";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import {
-    CAMPUS_TIMEZONE,
     parseTimeToMinutes,
     formatDateForDisplay,
     formatTimeForDisplay,
@@ -54,7 +53,6 @@ import {
     parseNaturalLanguageSearch,
     type NaturalLanguageSearchResult,
 } from "@/utils/naturalLanguageSearch";
-import { DateTime } from "luxon";
 
 interface LeftSidebarProps {
     facilityData: FacilityStatus | null;
@@ -215,14 +213,13 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     const facilityDataMatchesSelection = useMemo(() => {
         if (!facilityData || isCurrentDateTime) return true;
 
-        const responseDateTime = DateTime.fromISO(facilityData.timestamp).setZone(
-            CAMPUS_TIMEZONE,
-        );
-        if (!responseDateTime.isValid) return false;
+        const responseInstant = new Date(facilityData.timestamp);
+        if (Number.isNaN(responseInstant.getTime())) return false;
+        const responseDateTime = getCampusDateTimeParts(responseInstant);
 
         return (
-            responseDateTime.toFormat("yyyy-MM-dd") === selectedDateTime.date &&
-            responseDateTime.toFormat("HH:mm") === selectedDateTime.time.slice(0, 5)
+            responseDateTime.date === selectedDateTime.date &&
+            responseDateTime.time.slice(0, 5) === selectedDateTime.time.slice(0, 5)
         );
     }, [facilityData, isCurrentDateTime, selectedDateTime]);
 

--- a/src/utils/naturalLanguageSearch.ts
+++ b/src/utils/naturalLanguageSearch.ts
@@ -1,5 +1,6 @@
 import * as chrono from "chrono-node/en";
-import { DateTime } from "luxon";
+import { format } from "date-fns";
+import { TZDate, tzOffset } from "@date-fns/tz";
 import {
   CAMPUS_TIMEZONE,
   type CampusDateTime,
@@ -48,14 +49,12 @@ export function parseNaturalLanguageSearch(
     };
   }
 
-  const campusReference = DateTime.fromJSDate(referenceInstant).setZone(
-    CAMPUS_TIMEZONE,
-  );
+  const campusReference = TZDate.tz(CAMPUS_TIMEZONE, referenceInstant);
   const matches = chrono.parse(
     normalizedQuery,
     {
       instant: referenceInstant,
-      timezone: campusReference.offset,
+      timezone: tzOffset(CAMPUS_TIMEZONE, referenceInstant),
     },
     { forwardDate: true },
   );
@@ -99,29 +98,27 @@ export function parseNaturalLanguageSearch(
     };
   }
 
-  let target: DateTime;
+  let target: TZDate;
   if (match.start.isCertain("timezoneOffset")) {
     // Rebuilding relative durations from wall-clock parts loses time at DST boundaries.
-    target = DateTime.fromJSDate(match.start.date()).setZone(CAMPUS_TIMEZONE);
+    target = TZDate.tz(CAMPUS_TIMEZONE, match.start.date());
   } else {
-    target = DateTime.fromObject(
-      {
-        year: match.start.get("year") ?? campusReference.year,
-        month: match.start.get("month") ?? campusReference.month,
-        day: match.start.get("day") ?? campusReference.day,
-        hour: hasExplicitHour
-          ? (match.start.get("hour") ?? campusReference.hour)
-          : campusReference.hour,
-        minute: hasExplicitHour
-          ? (match.start.get("minute") ?? 0)
-          : campusReference.minute,
-        second: 0,
-      },
-      { zone: CAMPUS_TIMEZONE },
+    target = TZDate.tz(
+      CAMPUS_TIMEZONE,
+      match.start.get("year") ?? campusReference.getFullYear(),
+      (match.start.get("month") ?? campusReference.getMonth() + 1) - 1,
+      match.start.get("day") ?? campusReference.getDate(),
+      hasExplicitHour
+        ? (match.start.get("hour") ?? campusReference.getHours())
+        : campusReference.getHours(),
+      hasExplicitHour
+        ? (match.start.get("minute") ?? 0)
+        : campusReference.getMinutes(),
+      0,
     );
   }
 
-  if (!target.isValid) {
+  if (Number.isNaN(target.getTime())) {
     return {
       locationQuery,
       temporalText,
@@ -134,8 +131,8 @@ export function parseNaturalLanguageSearch(
     locationQuery,
     temporalText,
     dateTime: {
-      date: target.toFormat("yyyy-MM-dd"),
-      time: target.startOf("minute").toFormat("HH:mm:ss"),
+      date: format(target, "yyyy-MM-dd"),
+      time: format(target, "HH:mm':00'"),
     },
     error: null,
   };


### PR DESCRIPTION
This PR improves client load size by removing duplicate date-time library code from the main application route.

### Before

Client date handling imported Luxon even though `react-day-picker` already brought `date-fns` into the bundle. The main route chunk was 359.06 kB minified and 108.88 kB gzip.

### After

Client date handling uses `date-fns`, `@date-fns/tz`, and the existing `Intl` campus-time helper. The main route chunk is now 288.24 kB minified and 87.04 kB gzip, saving 70.82 kB minified and 21.84 kB gzip. Server date handling continues to use Luxon.

### Implementation notes

The date-fns packages are declared directly so client code does not rely on transitive dependencies from `react-day-picker`. Timezone-aware parsing retains the existing spring DST behavior.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests
- [x] `bun run check` (lint, 99 tests, production build, and typecheck)

### Release notes

- Reduce the main application route download size

### Code changes

| Section | LOC change |
| --- | --- |
| Apps | +26 / -32 |
| Config/tooling | +4 / -0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and time handling across campus time zones.
  * Increased accuracy when interpreting natural-language date and time searches.
  * Improved facility result matching for timestamps, including invalid or differently formatted date values.
  * Reduced inconsistencies between displayed campus times and search or filtering results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->