### PR TITLE
fix(analytics): track facility and room expansions in PostHog

### DIFF
--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -244,8 +244,10 @@ const IlliniSpotsPage: React.FC = () => {
 
   const handleMarkerClick = useCallback(
     (id: string, facilityType: FacilityType) => {
+      const facilityName = facilityData?.facilities[id]?.name;
       posthog.capture("facility_selected", {
         facility_id: id,
+        facility_name: facilityName,
         facility_type: facilityType,
         selection_source: "map",
       });
@@ -263,7 +265,7 @@ const IlliniSpotsPage: React.FC = () => {
         return getUpdatedAccordionItems(itemId, prevItems);
       });
     },
-    [posthog],
+    [facilityData, posthog],
   );
 
   const showFetchingOverlay = isAcademicFetching && !isAcademicLoading;

--- a/src/components/FacilityAccordion.tsx
+++ b/src/components/FacilityAccordion.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { usePostHog } from "@posthog/react";
 import {
   Accordion,
   AccordionContent,
@@ -78,6 +79,7 @@ export const FacilityAccordion: React.FC<FacilityAccordionProps> = ({
   idPrefix,
   filterCriteria = {},
 }) => {
+  const posthog = usePostHog();
   const facilityId = `${idPrefix}-${facility.id}`;
 
   const filteredAvailableCount = useMemo(() => {
@@ -90,6 +92,19 @@ export const FacilityAccordion: React.FC<FacilityAccordionProps> = ({
     }).length;
   }, [facility.rooms, filterCriteria]);
 
+  const handleToggle = () => {
+    const isExpanding = !expandedItems.includes(facilityId);
+    if (isExpanding) {
+      posthog.capture("facility_selected", {
+        facility_id: facility.id,
+        facility_name: facility.name,
+        facility_type: facilityType,
+        selection_source: "list",
+      });
+    }
+    toggleItem(facilityId);
+  };
+
   return (
     <AccordionItem
       value={facilityId}
@@ -100,8 +115,13 @@ export const FacilityAccordion: React.FC<FacilityAccordionProps> = ({
     >
       <div className="sticky top-0 bg-background z-10">
         <AccordionTrigger
-          onClick={() => toggleItem(facilityId)}
+          onClick={handleToggle}
           className="px-4 py-2 hover:no-underline hover:bg-muted group"
+          aria-label={`${facility.name} details`}
+          data-attr={`facility-accordion-${facility.id}`}
+          data-facility-id={facility.id}
+          data-facility-name={facility.name}
+          data-facility-type={facilityType}
         >
           <div className="flex items-center justify-between flex-1 mr-2">
             <div className="flex items-center gap-2 min-w-0 flex-1">
@@ -189,6 +209,8 @@ const LibraryRoomsAccordion: React.FC<LibraryRoomsAccordionProps> = ({
   idPrefix,
   filterCriteria = {},
 }) => {
+  const posthog = usePostHog();
+
   return (
     <Accordion type="multiple" value={expandedItems} className="w-full">
       {Object.entries(facility.rooms)
@@ -209,8 +231,25 @@ const LibraryRoomsAccordion: React.FC<LibraryRoomsAccordionProps> = ({
               {/* Sticky header for room name/status */}
               <div className="sticky top-0 bg-background z-5">
                 <AccordionTrigger
-                  onClick={() => toggleItem(roomId)}
+                  onClick={() => {
+                    const isExpanding = !expandedItems.includes(roomId);
+                    if (isExpanding) {
+                      posthog.capture("room_schedule_viewed", {
+                        facility_id: facility.id,
+                        facility_name: facility.name,
+                        facility_type: FacilityType.LIBRARY,
+                        room_number: roomName,
+                        selection_source: "accordion",
+                      });
+                    }
+                    toggleItem(roomId);
+                  }}
                   className="px-4 py-2 hover:no-underline hover:bg-muted/50 text-sm"
+                  aria-label={`${roomName} in ${facility.name}`}
+                  data-attr={`facility-${facility.id}-room-${roomName}`}
+                  data-facility-id={facility.id}
+                  data-facility-name={facility.name}
+                  data-room-name={roomName}
                 >
                   <div className="flex items-center justify-between flex-1 mr-2">
                     <div className="flex flex-col items-start text-left">
@@ -231,6 +270,8 @@ const LibraryRoomsAccordion: React.FC<LibraryRoomsAccordionProps> = ({
                   roomName={roomName}
                   room={libraryRoom}
                   facilityType={FacilityType.LIBRARY}
+                  facilityId={facility.id}
+                  facilityName={facility.name}
                 />
               </AccordionContent>
             </AccordionItem>
@@ -316,6 +357,8 @@ const AcademicRoomsAccordion: React.FC<AcademicRoomsAccordionProps> = ({
   idPrefix,
   filterCriteria = {},
 }) => {
+  const posthog = usePostHog();
+
   // Filter available and occupied rooms
   const availableRooms = useMemo(
     () =>
@@ -377,8 +420,25 @@ const AcademicRoomsAccordion: React.FC<AcademicRoomsAccordionProps> = ({
             >
               <AccordionItem value={roomAccordionId} className="border-b-0">
                 <AccordionTrigger
-                  onClick={() => toggleItem(roomAccordionId)}
+                  onClick={() => {
+                    const isExpanding = !expandedItems.includes(roomAccordionId);
+                    if (isExpanding) {
+                      posthog.capture("room_schedule_viewed", {
+                        facility_id: facility.id,
+                        facility_name: facility.name,
+                        facility_type: FacilityType.ACADEMIC,
+                        room_number: roomNumber,
+                        selection_source: "accordion",
+                      });
+                    }
+                    toggleItem(roomAccordionId);
+                  }}
                   className="py-2 px-2 text-sm hover:no-underline hover:bg-muted/20 rounded-md group [&[data-state=open]>svg]:text-primary"
+                  aria-label={`Room ${roomNumber} in ${facility.name}`}
+                  data-attr={`facility-${facility.id}-room-${roomNumber}`}
+                  data-facility-id={facility.id}
+                  data-facility-name={facility.name}
+                  data-room-number={roomNumber}
                 >
                   {/* Room details for the trigger */}
                   <div className="flex justify-between items-center w-full mr-2 text-left">
@@ -428,8 +488,25 @@ const AcademicRoomsAccordion: React.FC<AcademicRoomsAccordionProps> = ({
         }}
       >
         <AccordionTrigger
-          onClick={() => toggleItem(`${idPrefix}-${facility.id}-available`)}
+          onClick={() => {
+            const availableId = `${idPrefix}-${facility.id}-available`;
+            const isExpanding = !expandedItems.includes(availableId);
+            if (isExpanding) {
+              posthog.capture("facility_room_group_expanded", {
+                facility_id: facility.id,
+                facility_name: facility.name,
+                facility_type: FacilityType.ACADEMIC,
+                group_type: "available",
+                room_count: availableRooms.length,
+              });
+            }
+            toggleItem(availableId);
+          }}
           className="px-4 py-2 hover:no-underline hover:bg-muted/50 text-sm font-normal"
+          aria-label={`Available rooms in ${facility.name} (${availableRooms.length})`}
+          data-attr={`facility-${facility.id}-available-rooms`}
+          data-facility-id={facility.id}
+          data-facility-name={facility.name}
         >
           Available Rooms ({availableRooms.length})
         </AccordionTrigger>
@@ -452,8 +529,25 @@ const AcademicRoomsAccordion: React.FC<AcademicRoomsAccordionProps> = ({
         }}
       >
         <AccordionTrigger
-          onClick={() => toggleItem(`${idPrefix}-${facility.id}-occupied`)}
+          onClick={() => {
+            const occupiedId = `${idPrefix}-${facility.id}-occupied`;
+            const isExpanding = !expandedItems.includes(occupiedId);
+            if (isExpanding) {
+              posthog.capture("facility_room_group_expanded", {
+                facility_id: facility.id,
+                facility_name: facility.name,
+                facility_type: FacilityType.ACADEMIC,
+                group_type: "occupied",
+                room_count: occupiedRooms.length,
+              });
+            }
+            toggleItem(occupiedId);
+          }}
           className="px-4 py-2 hover:no-underline hover:bg-muted/50 text-sm font-normal"
+          aria-label={`Occupied rooms in ${facility.name} (${occupiedRooms.length})`}
+          data-attr={`facility-${facility.id}-occupied-rooms`}
+          data-facility-id={facility.id}
+          data-facility-name={facility.name}
         >
           Occupied Rooms ({occupiedRooms.length})
         </AccordionTrigger>

--- a/src/components/FacilityAccordion.tsx
+++ b/src/components/FacilityAccordion.tsx
@@ -95,7 +95,7 @@ export const FacilityAccordion: React.FC<FacilityAccordionProps> = ({
   const handleToggle = () => {
     const isExpanding = !expandedItems.includes(facilityId);
     if (isExpanding) {
-      posthog.capture("facility_selected", {
+      posthog.capture("facility_accordion_expanded", {
         facility_id: facility.id,
         facility_name: facility.name,
         facility_type: facilityType,
@@ -118,11 +118,10 @@ export const FacilityAccordion: React.FC<FacilityAccordionProps> = ({
           onClick={handleToggle}
           className="px-4 py-2 hover:no-underline hover:bg-muted group"
           aria-label={`${facility.name} details`}
-          data-attr={`facility-accordion-${facility.id}`}
-          data-facility-id={facility.id}
-          data-facility-name={facility.name}
-          data-facility-type={facilityType}
         >
+          <span className="sr-only" aria-hidden="true">
+            {facility.name}
+          </span>
           <div className="flex items-center justify-between flex-1 mr-2">
             <div className="flex items-center gap-2 min-w-0 flex-1">
               <span className="font-medium truncate">{facility.name}</span>
@@ -246,10 +245,6 @@ const LibraryRoomsAccordion: React.FC<LibraryRoomsAccordionProps> = ({
                   }}
                   className="px-4 py-2 hover:no-underline hover:bg-muted/50 text-sm"
                   aria-label={`${roomName} in ${facility.name}`}
-                  data-attr={`facility-${facility.id}-room-${roomName}`}
-                  data-facility-id={facility.id}
-                  data-facility-name={facility.name}
-                  data-room-name={roomName}
                 >
                   <div className="flex items-center justify-between flex-1 mr-2">
                     <div className="flex flex-col items-start text-left">
@@ -435,10 +430,6 @@ const AcademicRoomsAccordion: React.FC<AcademicRoomsAccordionProps> = ({
                   }}
                   className="py-2 px-2 text-sm hover:no-underline hover:bg-muted/20 rounded-md group [&[data-state=open]>svg]:text-primary"
                   aria-label={`Room ${roomNumber} in ${facility.name}`}
-                  data-attr={`facility-${facility.id}-room-${roomNumber}`}
-                  data-facility-id={facility.id}
-                  data-facility-name={facility.name}
-                  data-room-number={roomNumber}
                 >
                   {/* Room details for the trigger */}
                   <div className="flex justify-between items-center w-full mr-2 text-left">
@@ -504,9 +495,6 @@ const AcademicRoomsAccordion: React.FC<AcademicRoomsAccordionProps> = ({
           }}
           className="px-4 py-2 hover:no-underline hover:bg-muted/50 text-sm font-normal"
           aria-label={`Available rooms in ${facility.name} (${availableRooms.length})`}
-          data-attr={`facility-${facility.id}-available-rooms`}
-          data-facility-id={facility.id}
-          data-facility-name={facility.name}
         >
           Available Rooms ({availableRooms.length})
         </AccordionTrigger>
@@ -545,9 +533,6 @@ const AcademicRoomsAccordion: React.FC<AcademicRoomsAccordionProps> = ({
           }}
           className="px-4 py-2 hover:no-underline hover:bg-muted/50 text-sm font-normal"
           aria-label={`Occupied rooms in ${facility.name} (${occupiedRooms.length})`}
-          data-attr={`facility-${facility.id}-occupied-rooms`}
-          data-facility-id={facility.id}
-          data-facility-name={facility.name}
         >
           Occupied Rooms ({occupiedRooms.length})
         </AccordionTrigger>

--- a/src/components/FacilityRoomDetails.tsx
+++ b/src/components/FacilityRoomDetails.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { usePostHog } from "@posthog/react";
 import {
   FacilityRoomProps,
   TimeBlockProps,
@@ -93,7 +94,10 @@ export const RoomSchedule = ({ slots }: RoomScheduleProps) => {
 export default function FacilityRoomDetails({
   roomName,
   room,
+  facilityId,
+  facilityName,
 }: FacilityRoomProps) {
+  const posthog = usePostHog();
   const [isImageLoading, setIsImageLoading] = useState(true);
 
   // Use the discriminated union to determine room type
@@ -102,8 +106,29 @@ export default function FacilityRoomDetails({
     return (
       <div className="px-4 py-2">
         <div className="flex gap-2 mb-2">
-          <Button asChild variant="outline" size="sm" className="flex-1">
-            <a href={libraryRoom.url} target="_blank" rel="noopener noreferrer">
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="flex-1"
+            data-attr={facilityId ? `reserve-${facilityId}-room-${roomName}` : `reserve-room-${roomName}`}
+            data-facility-id={facilityId}
+            data-facility-name={facilityName}
+            data-room-name={roomName}
+          >
+            <a
+              href={libraryRoom.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => {
+                posthog.capture("library_room_reservation_opened", {
+                  facility_id: facilityId,
+                  facility_name: facilityName,
+                  room_number: roomName,
+                  url: libraryRoom.url,
+                });
+              }}
+            >
               <BookOpen className="w-4 h-4 mr-2" />
               Reserve
             </a>

--- a/src/components/FacilityRoomDetails.tsx
+++ b/src/components/FacilityRoomDetails.tsx
@@ -111,10 +111,6 @@ export default function FacilityRoomDetails({
             variant="outline"
             size="sm"
             className="flex-1"
-            data-attr={facilityId ? `reserve-${facilityId}-room-${roomName}` : `reserve-room-${roomName}`}
-            data-facility-id={facilityId}
-            data-facility-name={facilityName}
-            data-room-name={roomName}
           >
             <a
               href={libraryRoom.url}
@@ -125,7 +121,6 @@ export default function FacilityRoomDetails({
                   facility_id: facilityId,
                   facility_name: facilityName,
                   room_number: roomName,
-                  url: libraryRoom.url,
                 });
               }}
             >

--- a/src/components/FavoritesSection.tsx
+++ b/src/components/FavoritesSection.tsx
@@ -55,6 +55,19 @@ export const FavoritesSection: React.FC<FavoritesSectionProps> = ({
               key={favorite.id}
               className="mx-4 px-3 py-2 rounded-md hover:bg-muted/50 cursor-pointer transition-colors"
               onClick={handleFacilityClick}
+              data-attr={`favorite-${favorite.id}`}
+              data-facility-id={favorite.id}
+              data-facility-name={favorite.name}
+              data-facility-type={favorite.type}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleFacilityClick();
+                }
+              }}
+              aria-label={`Favorite: ${favorite.name}`}
             >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2 min-w-0 flex-1">

--- a/src/components/FavoritesSection.tsx
+++ b/src/components/FavoritesSection.tsx
@@ -11,7 +11,11 @@ import { Star } from 'lucide-react';
 interface FavoritesSectionProps {
   favorites: FavoriteItem[];
   facilityData: FacilityStatus | null;
-  onFavoriteClick: (facilityId: string, type: 'library' | 'academic') => void;
+  onFavoriteClick: (
+    facilityId: string,
+    type: 'library' | 'academic',
+    facilityName: string,
+  ) => void;
   onToggleFavorite: (item: FavoriteItem) => void;
 }
 
@@ -47,7 +51,7 @@ export const FavoritesSection: React.FC<FavoritesSectionProps> = ({
           };
 
           const handleFacilityClick = () => {
-            onFavoriteClick(favorite.id, favorite.type);
+            onFavoriteClick(favorite.id, favorite.type, favorite.name);
           };
           
           return (
@@ -55,19 +59,6 @@ export const FavoritesSection: React.FC<FavoritesSectionProps> = ({
               key={favorite.id}
               className="mx-4 px-3 py-2 rounded-md hover:bg-muted/50 cursor-pointer transition-colors"
               onClick={handleFacilityClick}
-              data-attr={`favorite-${favorite.id}`}
-              data-facility-id={favorite.id}
-              data-facility-name={favorite.name}
-              data-facility-type={favorite.type}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  handleFacilityClick();
-                }
-              }}
-              aria-label={`Favorite: ${favorite.name}`}
             >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2 min-w-0 flex-1">

--- a/src/components/RoomSearchResultCard.tsx
+++ b/src/components/RoomSearchResultCard.tsx
@@ -149,10 +149,6 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
             className="h-8 text-xs font-medium gap-1.5 hover:bg-secondary"
             aria-expanded={isScheduleOpen}
             aria-label={`${isScheduleOpen ? "Hide" : "View"} schedule for room ${roomNumber} in ${facility.name}`}
-            data-attr={`search-schedule-${facility.id}-room-${roomNumber}`}
-            data-facility-id={facility.id}
-            data-facility-name={facility.name}
-            data-room-number={roomNumber}
           >
             <Calendar className="w-3.5 h-3.5" />
             {isScheduleOpen ? "Hide Schedule" : "View Schedule"}
@@ -172,10 +168,6 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
                   variant="outline"
                   size="sm"
                   className="h-8 text-xs font-medium gap-1.5 hover:bg-secondary"
-                  data-attr={`search-reserve-${facility.id}-room-${roomNumber}`}
-                  data-facility-id={facility.id}
-                  data-facility-name={facility.name}
-                  data-room-number={roomNumber}
                 >
                   <a
                     href={libraryRoom.url}
@@ -186,7 +178,6 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
                         facility_id: facility.id,
                         facility_name: facility.name,
                         room_number: roomNumber,
-                        url: libraryRoom.url,
                       })
                     }
                   >

--- a/src/components/RoomSearchResultCard.tsx
+++ b/src/components/RoomSearchResultCard.tsx
@@ -43,8 +43,10 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
     if (openingSchedule) {
       posthog.capture("room_schedule_viewed", {
         facility_id: facility.id,
+        facility_name: facility.name,
         facility_type: facilityType,
         room_number: roomNumber,
+        selection_source: "search",
       });
     }
   };
@@ -146,6 +148,11 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
             onClick={toggleSchedule}
             className="h-8 text-xs font-medium gap-1.5 hover:bg-secondary"
             aria-expanded={isScheduleOpen}
+            aria-label={`${isScheduleOpen ? "Hide" : "View"} schedule for room ${roomNumber} in ${facility.name}`}
+            data-attr={`search-schedule-${facility.id}-room-${roomNumber}`}
+            data-facility-id={facility.id}
+            data-facility-name={facility.name}
+            data-room-number={roomNumber}
           >
             <Calendar className="w-3.5 h-3.5" />
             {isScheduleOpen ? "Hide Schedule" : "View Schedule"}
@@ -165,6 +172,10 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
                   variant="outline"
                   size="sm"
                   className="h-8 text-xs font-medium gap-1.5 hover:bg-secondary"
+                  data-attr={`search-reserve-${facility.id}-room-${roomNumber}`}
+                  data-facility-id={facility.id}
+                  data-facility-name={facility.name}
+                  data-room-number={roomNumber}
                 >
                   <a
                     href={libraryRoom.url}
@@ -173,7 +184,9 @@ export const RoomSearchResultCard: React.FC<RoomSearchResultCardProps> = ({
                     onClick={() =>
                       posthog.capture("library_room_reservation_opened", {
                         facility_id: facility.id,
+                        facility_name: facility.name,
                         room_number: roomNumber,
+                        url: libraryRoom.url,
                       })
                     }
                   >

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -297,8 +297,10 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
 
     const handleFavoriteClick = useCallback(
         (facilityId: string, type: "library" | "academic") => {
+            const facilityName = facilityData?.facilities[facilityId]?.name;
             posthog.capture("facility_selected", {
                 facility_id: facilityId,
+                facility_name: facilityName,
                 facility_type: type,
                 selection_source: "favorites",
             });
@@ -314,7 +316,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
 
             scrollToAccordion(accordionId);
         },
-        [expandedItems, posthog, setExpandedItems, scrollToAccordion],
+        [expandedItems, facilityData, posthog, setExpandedItems, scrollToAccordion],
     );
 
     const matchingRoomsCount = useMemo(() => {

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -296,8 +296,11 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     }, [facilityData, filterFacilitiesByAvailability]);
 
     const handleFavoriteClick = useCallback(
-        (facilityId: string, type: "library" | "academic") => {
-            const facilityName = facilityData?.facilities[facilityId]?.name;
+        (
+            facilityId: string,
+            type: "library" | "academic",
+            facilityName: string,
+        ) => {
             posthog.capture("facility_selected", {
                 facility_id: facilityId,
                 facility_name: facilityName,
@@ -316,7 +319,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
 
             scrollToAccordion(accordionId);
         },
-        [expandedItems, facilityData, posthog, setExpandedItems, scrollToAccordion],
+        [expandedItems, posthog, setExpandedItems, scrollToAccordion],
     );
 
     const matchingRoomsCount = useMemo(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -219,6 +219,8 @@ export interface FacilityRoomProps {
   room: FacilityRoom;
   // facilityType for facility-level decisions
   facilityType: FacilityType;
+  facilityId?: string;
+  facilityName?: string;
 }
 export interface AccordionRefs {
   [key: string]: HTMLDivElement | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -219,8 +219,8 @@ export interface FacilityRoomProps {
   room: FacilityRoom;
   // facilityType for facility-level decisions
   facilityType: FacilityType;
-  facilityId?: string;
-  facilityName?: string;
+  facilityId: string;
+  facilityName: string;
 }
 export interface AccordionRefs {
   [key: string]: HTMLDivElement | null;


### PR DESCRIPTION
This PR fixes a bug where PostHog activity did not identify which facility accordion a user expanded. It also adds structured facility and room context to related analytics events.

### Before

The facility name was nested behind layout divs, so PostHog autocapture did not extract it as button text and displayed a generic `clicked button` activity entry. Facility, room-group, and accordion schedule expansions also lacked consistent custom events with facility context.

### After

Facility triggers expose the facility name directly to PostHog text extraction, producing activity such as `clicked button with text "Grainger Engineering Library"`. Expansions emit distinct `facility_accordion_expanded`, `facility_room_group_expanded`, and `room_schedule_viewed` events with facility and room context. Reservation openings and existing map, favorite, and search events now include the same useful names without capturing destination URLs.

### Implementation notes

Custom events carry structured analytics properties; the DOM does not duplicate them in manually added `data-*` attributes. Expansion events fire only when an accordion opens.

### Change type

- [x] `bugfix`

### Test plan

1. In a PostHog-enabled environment, expand a facility and confirm its autocapture activity includes the facility name.
2. Expand available or occupied groups and individual rooms, then confirm the custom events include the expected facility and room properties.
3. Open a library reservation and confirm the event identifies the facility and room without a URL property.

- [x] Existing automated checks (`bun run check`: ESLint, 99 tests, production build, and TypeScript)
- [ ] End-to-end analytics verification in PostHog

### Release notes

- Fix missing facility and room context in PostHog activity and analytics events.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps | +128 / -12 |