### PR TITLE
perf(map): adopt Mapbox GL JS modular ESM build

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "hono": "^4.13.3",
         "lucide-react": "^0.454.0",
         "luxon": "^3.7.2",
-        "mapbox-gl": "^3.5.1",
+        "mapbox-gl": "^3.29.0",
         "posthog-js": "^1.422.4",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "hono": "^4.13.3",
     "lucide-react": "^0.454.0",
     "luxon": "^3.7.2",
-    "mapbox-gl": "^3.5.1",
+    "mapbox-gl": "^3.29.0",
     "posthog-js": "^1.422.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import type { FeatureCollection, Point } from "geojson";
-import mapboxgl from "mapbox-gl";
+import * as mapboxgl from "mapbox-gl/esm";
 import "mapbox-gl/dist/mapbox-gl.css";
 import {
   MarkerData,
@@ -71,12 +71,13 @@ export default function FacilityMap({
       return;
     }
 
-    mapboxgl.accessToken = token;
+    mapboxgl.setAccessToken(token);
 
     let timeoutId: number | undefined;
 
     try {
       const mapInstance = new mapboxgl.Map({
+        accessToken: token,
         container: mapContainer.current,
         style: styleUrl,
         // minZoom: 15.2,


### PR DESCRIPTION
### Summary

Upgrades `mapbox-gl` to `^3.29.0` and switches imports to the modular ESM entrypoint (`mapbox-gl/esm`).

### Before

The main map chunk shipped as a monolithic bundle at **1,834.85 kB minified (505.91 kB gzip)**, triggering Vite's 1600 kB chunk warning and downloading unused rendering subsystems upfront.

### After

The main map chunk is reduced to **805.39 kB minified (211.80 kB gzip)**, a reduction of **1,029.46 kB (-56%)** for initial download. Heavy 3D standard basemap features and HD shaders are split into on-demand chunks that load in the background only when required by the active style.

### Implementation notes

- Upgraded `mapbox-gl` from `3.5.1` to `3.29.0` in `package.json` and `bun.lock`.
- Updated `src/components/map.tsx` to import `* as mapboxgl` from `mapbox-gl/esm`.
- Passed `accessToken` directly into `new mapboxgl.Map({ accessToken, ... })` and initialized via `mapboxgl.setAccessToken(token)`.
- Verified TypeScript compatibility with GL JS ESM typings.

### Test plan

- [x] Automated checks (`bun run check`: ESLint, 99 unit tests, typecheck, production Vite build).
- [x] Deployed and verified on staging (`illinispots-staging` / https://staging.illinispots.com) with interactive 3D map inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map initialization and authentication for more reliable map loading.
  * Updated the mapping library to a newer version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->