### PR TITLE
perf(search): lazy-load natural language parser

### DIFF
--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -50,10 +50,10 @@ import {
     formatTimeForDisplay,
     getCampusDateTimeParts,
 } from "@/utils/time";
-import {
-    parseNaturalLanguageSearch,
-    type NaturalLanguageSearchResult,
-} from "@/utils/naturalLanguageSearch";
+import type { NaturalLanguageSearchResult } from "@/utils/naturalLanguageSearch";
+
+type NaturalLanguageParser =
+    typeof import("@/utils/naturalLanguageSearch")["parseNaturalLanguageSearch"];
 
 interface LeftSidebarProps {
     facilityData: FacilityStatus | null;
@@ -173,6 +173,8 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     const accordionRefs = useRef<AccordionRefs>({});
     const scrollAreaRef = useRef<HTMLDivElement | null>(null);
     const [searchTerm, setSearchTerm] = useState("");
+    const [naturalLanguageParser, setNaturalLanguageParser] =
+        useState<NaturalLanguageParser | null>(null);
     const { favorites, toggleFavorite } = useFavorites();
     const {
         selectedDateTime,
@@ -194,11 +196,27 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
 
     const hasActiveFilters = !!minDuration || !!freeUntil;
     const isSearching = searchTerm.trim().length > 0;
-    const naturalSearch = useMemo(
-        () => parseNaturalLanguageSearch(searchTerm),
-        [searchTerm],
-    );
+    const naturalSearch = useMemo<NaturalLanguageSearchResult>(() => {
+        if (naturalLanguageParser) {
+            return naturalLanguageParser(searchTerm);
+        }
+
+        return {
+            locationQuery: searchTerm.trim(),
+            temporalText: null,
+            dateTime: null,
+            error: null,
+        };
+    }, [naturalLanguageParser, searchTerm]);
     const hasTemporalSearch = naturalSearch.temporalText !== null;
+
+    const loadNaturalLanguageParser = useCallback(() => {
+        void import("@/utils/naturalLanguageSearch").then(
+            ({ parseNaturalLanguageSearch }) => {
+                setNaturalLanguageParser(() => parseNaturalLanguageSearch);
+            },
+        );
+    }, []);
 
     const applyNaturalSearch = useCallback(() => {
         if (naturalSearch.error || !naturalSearch.dateTime) return;
@@ -372,6 +390,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                             <Input
                                 type="text"
                                 value={searchTerm}
+                                onFocus={loadNaturalLanguageParser}
                                 onChange={(e) => setSearchTerm(e.target.value)}
                                 placeholder="Try CIF tmrw 2pm"
                                 className={`pl-8 ${searchTerm ? "pr-8" : ""} h-9 md:h-9 rounded-full text-sm`}


### PR DESCRIPTION
This PR improves initial client loading by deferring natural language date parsing until the user focuses the search field.

### Before

The search sidebar statically imported the natural language parser, putting `chrono-node` in the initial client bundle even when search was never used.

### After

The sidebar dynamically imports the parser on search focus. Ordinary text search remains available while the import resolves, and Vite emits the parser as a separate 51.24 kB chunk (15.15 kB gzip).

### Change type

- [x] `improvement`

### Test plan

- [x] Natural language parser unit tests
- [x] TypeScript typecheck
- [x] ESLint
- [x] Production build

### Release notes

- Improve initial page loading by loading natural language date parsing on demand

### Code changes

| Section | LOC change |
| --- | --- |
| Apps | +27 / -8 |