### PR TITLE
perf(analytics): load PostHog asynchronously

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@date-fns/tz": "^1.5.0",
         "@fontsource-variable/inter": "^5.3.0",
         "@leeoniya/ufuzzy": "^1.0.19",
-        "@posthog/react": "^1.10.5",
         "@radix-ui/react-accordion": "^1.2.1",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-icons": "^1.3.2",
@@ -193,8 +192,6 @@
     "@posthog/browser-common": ["@posthog/browser-common@0.6.2", "", { "dependencies": { "@posthog/core": "^1.49.1", "@posthog/types": "^1.407.1" } }, "sha512-AZRETXzMXoCqNLGftKN7wtyhI+Da8y3WSYLrVzCyd7CSA2pIas1OjT4wsO3ncvX+Ezg0FJw5iSr84VtyVUcZ0g=="],
 
     "@posthog/core": ["@posthog/core@1.49.2", "", { "dependencies": { "@posthog/types": "^1.407.1" } }, "sha512-AXHDo/4nisUg7OPG1TQNgREK7n+chBQXLQyttp7bDTDsDg2k9lV06TmnpvuNbwJs53q9mP9hjezKEZu4fYadfg=="],
-
-    "@posthog/react": ["@posthog/react@1.10.5", "", { "peerDependencies": { "@types/react": ">=16.8.0", "posthog-js": ">=1.257.2", "react": ">=16.8.0" }, "optionalPeers": ["@types/react"] }, "sha512-lehh9+mJwb6iEjRBkIvh8olnJ6RV+YgQgdgJ6fdTr+T7EMoml/G1k+q92Oil8vZPcA9Dzg+2n0xaLY5yZrY3YA=="],
 
     "@posthog/types": ["@posthog/types@1.407.1", "", {}, "sha512-WhbkXPC2rgylXqmxHqv70ffI3k+KxyR6s7DBIfr5NvIqHkxp6v0pk31D/jbz0DNVbzwkLjyll2pxr4FNbJiYzg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@date-fns/tz": "^1.5.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@leeoniya/ufuzzy": "^1.0.19",
-    "@posthog/react": "^1.10.5",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-icons": "^1.3.2",

--- a/src/client/analytics.test.ts
+++ b/src/client/analytics.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, mock } from "bun:test";
+import { createBufferedAnalyticsClient } from "./analytics";
+
+describe("createBufferedAnalyticsClient", () => {
+  it("forwards captures queued before PostHog loads", () => {
+    const analytics = createBufferedAnalyticsClient();
+    const capture = mock(() => undefined);
+
+    analytics.client.capture("facility_selected", { facilityId: "bif" });
+    analytics.connect(capture);
+    analytics.client.capture("room_schedule_viewed", { roomId: "1404" });
+
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(capture).toHaveBeenNthCalledWith(1, "facility_selected", {
+      facilityId: "bif",
+    });
+    expect(capture).toHaveBeenNthCalledWith(2, "room_schedule_viewed", {
+      roomId: "1404",
+    });
+  });
+
+  it("drops queued and future captures when analytics is disabled", () => {
+    const analytics = createBufferedAnalyticsClient();
+    const capture = mock(() => undefined);
+
+    analytics.client.capture("facility_selected");
+    analytics.disable();
+    analytics.connect(capture);
+    analytics.client.capture("room_schedule_viewed");
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/src/client/analytics.tsx
+++ b/src/client/analytics.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { getClientConfig } from "@/client/config";
+import { Sentry } from "@/client/observability";
+
+type AnalyticsProperties = Record<string, unknown>;
+type Capture = (
+  eventName: string,
+  properties?: AnalyticsProperties,
+) => void;
+type QueuedCapture = Parameters<Capture>;
+
+export interface AnalyticsClient {
+  capture: Capture;
+}
+
+export interface BufferedAnalyticsClient {
+  client: AnalyticsClient;
+  connect: (capture: Capture) => void;
+  disable: () => void;
+}
+
+const MAX_QUEUED_CAPTURES = 100;
+const disabledClient: AnalyticsClient = { capture: () => undefined };
+const AnalyticsContext = React.createContext<AnalyticsClient>(disabledClient);
+
+export function createBufferedAnalyticsClient(): BufferedAnalyticsClient {
+  let destination: Capture | undefined;
+  let queuedCaptures: QueuedCapture[] = [];
+  let disabled = false;
+
+  return {
+    client: {
+      capture: (...capture) => {
+        if (destination) {
+          destination(...capture);
+        } else if (queuedCaptures.length < MAX_QUEUED_CAPTURES) {
+          queuedCaptures.push(capture);
+        }
+      },
+    },
+    connect: (capture) => {
+      if (disabled) return;
+      destination = capture;
+      const pendingCaptures = queuedCaptures;
+      queuedCaptures = [];
+      pendingCaptures.forEach((pendingCapture) => capture(...pendingCapture));
+    },
+    disable: () => {
+      disabled = true;
+      destination = disabledClient.capture;
+      queuedCaptures = [];
+    },
+  };
+}
+
+export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
+  const [analytics] = React.useState(createBufferedAnalyticsClient);
+
+  React.useEffect(() => {
+    const { posthogProjectToken, posthogHost } = getClientConfig();
+    if (!posthogProjectToken || !posthogHost) {
+      analytics.disable();
+      return;
+    }
+
+    let cancelled = false;
+
+    void import("posthog-js")
+      .then(({ default: posthog }) => {
+        if (cancelled) return;
+
+        const client = posthog.init(posthogProjectToken, {
+          api_host: posthogHost,
+          defaults: "2026-01-30",
+          debug: import.meta.env.DEV,
+        });
+        analytics.connect(client.capture.bind(client));
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        analytics.disable();
+        Sentry.captureException(error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [analytics]);
+
+  return (
+    <AnalyticsContext.Provider value={analytics.client}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+}
+
+export function usePostHog(): AnalyticsClient {
+  return React.useContext(AnalyticsContext);
+}

--- a/src/client/providers.tsx
+++ b/src/client/providers.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { DateTimeProvider } from "@/contexts/DateTimeContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { TouchProvider } from "@/components/ui/HybridTooltip";
+import { AnalyticsProvider } from "@/client/analytics";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = React.useState(
@@ -22,12 +23,14 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <DateTimeProvider>
-          <TouchProvider>{children}</TouchProvider>
-        </DateTimeProvider>
-      </ThemeProvider>
-    </QueryClientProvider>
+    <AnalyticsProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <DateTimeProvider>
+            <TouchProvider>{children}</TouchProvider>
+          </DateTimeProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </AnalyticsProvider>
   );
 }

--- a/src/client/routes/__root.tsx
+++ b/src/client/routes/__root.tsx
@@ -1,11 +1,9 @@
 import { useEffect } from "react";
-import { PostHogProvider } from "@posthog/react";
 import {
   Outlet,
   createRootRoute,
   type ErrorComponentProps,
 } from "@tanstack/react-router";
-import { getClientConfig } from "@/client/config";
 import { Sentry } from "@/client/observability";
 
 function RootError({ error, reset }: ErrorComponentProps) {
@@ -33,24 +31,7 @@ function RootError({ error, reset }: ErrorComponentProps) {
 }
 
 function RootComponent() {
-  const config = getClientConfig();
-
-  if (!config.posthogProjectToken || !config.posthogHost) {
-    return <Outlet />;
-  }
-
-  return (
-    <PostHogProvider
-      apiKey={config.posthogProjectToken}
-      options={{
-        api_host: config.posthogHost,
-        defaults: "2026-01-30",
-        debug: import.meta.env.DEV,
-      }}
-    >
-      <Outlet />
-    </PostHogProvider>
-  );
+  return <Outlet />;
 }
 
 export const Route = createRootRoute({

--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -8,7 +8,7 @@ import React, {
   Suspense,
 } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { usePostHog } from "@posthog/react";
+import { usePostHog } from "@/client/analytics";
 import { getUpdatedAccordionItems } from "@/utils/accordion";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import {

--- a/src/components/AddFavoritesDialog.tsx
+++ b/src/components/AddFavoritesDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { usePostHog } from '@posthog/react';
+import { usePostHog } from '@/client/analytics';
 import {
     Dialog,
     DialogContent,

--- a/src/components/DateTimeButton.tsx
+++ b/src/components/DateTimeButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { usePostHog } from "@posthog/react";
+import { usePostHog } from "@/client/analytics";
 import { Button } from "@/components/ui/button";
 import { CalendarClock } from "lucide-react";
 import { DateTimePicker } from "@/components/ui/date-time-picker";

--- a/src/components/FacilityAccordion.tsx
+++ b/src/components/FacilityAccordion.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { usePostHog } from "@posthog/react";
+import { usePostHog } from "@/client/analytics";
 import {
   Accordion,
   AccordionContent,

--- a/src/components/FacilityRoomDetails.tsx
+++ b/src/components/FacilityRoomDetails.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { usePostHog } from "@posthog/react";
+import { usePostHog } from "@/client/analytics";
 import {
   FacilityRoomProps,
   TimeBlockProps,

--- a/src/components/RoomFilter.tsx
+++ b/src/components/RoomFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { usePostHog } from "@posthog/react";
+import { usePostHog } from "@/client/analytics";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {

--- a/src/components/RoomSearchResultCard.tsx
+++ b/src/components/RoomSearchResultCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { usePostHog } from "@posthog/react";
+import { usePostHog } from "@/client/analytics";
 import { SearchResultRoom } from "@/utils/searchUtils";
 import { AcademicRoom, FacilityType, LibraryRoom, RoomStatus } from "@/types";
 import { RoomBadge } from "@/components/RoomBadge";

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -8,7 +8,7 @@ import React, {
     memo,
     useState,
 } from "react";
-import { usePostHog } from "@posthog/react";
+import { usePostHog } from "@/client/analytics";
 import { getUpdatedAccordionItems } from "@/utils/accordion";
 import { Accordion } from "@/components/ui/accordion";
 import { ScrollArea } from "@/components/ui/scroll-area";


### PR DESCRIPTION
This PR improves initial load performance so the app can render without first downloading and parsing optional analytics.

### Before

PostHog and its React integration were statically imported by the root route, keeping the SDK in the initial module graph. The production entry was 273.6 kB gzip.

### After

PostHog loads after the app mounts as an 86.0 kB gzip async chunk. The entry plus its startup preload is now 189.2 kB gzip, an 84.4 kB reduction. Captures made before initialization are buffered, while missing configuration or a load failure disables analytics without affecting the app.

### Implementation notes

The buffer is capped at 100 events. SDK loading failures are reported through the existing Sentry integration, and the unused `@posthog/react` dependency is removed.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests — cover buffered delivery and disabled analytics
- [x] Full `bun run check` — lint, 101 tests, production build, and typecheck
- [x] Production bundle inspection — verify PostHog is emitted as an async chunk

### Release notes

- Improve initial page loading by loading analytics asynchronously

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +118 / -35 |
| Tests          | +33 / -0   |
| Config/tooling | +0 / -4    |