### PR TITLE
fix(workflow): run Tableau refresh earlier

### DIFF
--- a/.github/workflows/tableau-daily-events.yml
+++ b/.github/workflows/tableau-daily-events.yml
@@ -2,8 +2,9 @@ name: Tableau daily events
 
 on:
   schedule:
-    # 5:17 AM CST / 6:17 AM CDT. The offset changes because GitHub cron uses UTC.
-    - cron: "17 11 * * *"
+    # Run early enough to absorb GitHub scheduler delays before the 7:00 AM deadline.
+    - cron: "17 1 * * *"
+      timezone: "America/Chicago"
   workflow_dispatch:
 
 permissions:
@@ -48,11 +49,13 @@ jobs:
       - name: Start Sentry monitor
         id: sentry-monitor
         continue-on-error: true
+        # 313 minutes after 1:17 AM is the 6:30 AM Central freshness deadline.
         run: >-
           python sentry_monitor.py start
           --monitor-slug tableau-daily-events
-          --schedule "17 11 * * *"
-          --checkin-margin 30
+          --schedule "17 1 * * *"
+          --timezone "America/Chicago"
+          --checkin-margin 313
           --max-runtime 15
 
       - name: Update Tableau daily events

--- a/data-pipeline/sentry_monitor.py
+++ b/data-pipeline/sentry_monitor.py
@@ -55,7 +55,7 @@ def start_monitor(args: argparse.Namespace) -> None:
                 status=MonitorStatus.IN_PROGRESS,
                 monitor_config={
                     "schedule": {"type": "crontab", "value": args.schedule},
-                    "timezone": "UTC",
+                    "timezone": args.timezone,
                     "checkin_margin": args.checkin_margin,
                     "max_runtime": args.max_runtime,
                 },
@@ -196,6 +196,7 @@ def parse_args() -> argparse.Namespace:
     start_parser = subparsers.add_parser("start")
     start_parser.add_argument("--monitor-slug", required=True)
     start_parser.add_argument("--schedule", required=True)
+    start_parser.add_argument("--timezone", default="UTC")
     start_parser.add_argument("--checkin-margin", type=int, required=True)
     start_parser.add_argument("--max-runtime", type=int, required=True)
     start_parser.set_defaults(handler=start_monitor)


### PR DESCRIPTION
This PR fixes a bug where delayed GitHub cron delivery can cause the Tableau daily refresh to miss the morning data deadline.

### Before

The refresh was scheduled for 6:17 AM during daylight saving time, leaving only 43 minutes before the 7:00 AM Central deadline. Recent scheduled runs arrived several hours late.

### After

The refresh is scheduled for 1:17 AM in `America/Chicago`, providing nearly six hours of buffer while handling daylight-saving changes. The Sentry monitor uses the same timezone and reports a missed start at 6:30 AM Central.

### Change type

- [x] `bugfix`

### Test plan

- [x] Compile the Python data-pipeline modules
- [x] Parse the workflow as YAML
- [x] Verify the generated Sentry monitor configuration with a smoke test
- [x] Run `git diff --check`

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +2 / -1    |
| Config/tooling | +7 / -4    |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Daily events now run at 1:17 AM Central Time and are expected to be refreshed by 6:30 AM Central Time.
  * Monitoring now supports timezone-aware schedules and reflects the updated run window.
  * Improved monitoring tolerance helps accommodate the longer overnight processing window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->