### PR TITLE
feat(ui): constrain map-off view to max width

### DIFF
--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -270,7 +270,7 @@ const IlliniSpotsPage: React.FC = () => {
 
   const showFetchingOverlay = isAcademicFetching && !isAcademicLoading;
   const mainContentClasses = `h-screen flex ${
-    showMap ? "md:flex-row" : ""
+    showMap ? "md:flex-row" : "items-center bg-muted/20"
   } flex-col`;
 
   return (
@@ -289,8 +289,10 @@ const IlliniSpotsPage: React.FC = () => {
 
       <div
         className={`${
-          showMap ? "md:w-[37%] h-[60vh] md:h-screen" : "h-screen"
-        } w-full flex-1 overflow-hidden order-2 md:order-1 relative`}
+          showMap
+            ? "md:w-[37%] h-[60vh] md:h-screen order-2 md:order-1"
+            : "h-screen max-w-3xl md:border-x border-border shadow-xs"
+        } w-full flex-1 overflow-hidden relative`}
       >
         <LeftSidebar
           facilityData={facilityData || null}

--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -291,7 +291,7 @@ const IlliniSpotsPage: React.FC = () => {
         className={`${
           showMap
             ? "md:w-[37%] h-[60vh] md:h-screen order-2 md:order-1"
-            : "h-screen max-w-3xl md:border-x border-border shadow-xs"
+            : "h-screen max-w-3xl md:border-x border-border shadow-sm"
         } w-full flex-1 overflow-hidden relative`}
       >
         <LeftSidebar

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -371,7 +371,11 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     const [isFavoritesDialogOpen, setIsFavoritesDialogOpen] = useState(false);
 
     return (
-        <div className="h-full bg-background border-t md:border-t-0 md:border-l flex flex-col relative">
+        <div
+            className={`h-full bg-background flex flex-col relative ${
+                showMap ? "border-t md:border-t-0 md:border-r" : ""
+            }`}
+        >
             <div className="sidebar-header py-2 px-3 md:py-3 md:px-4 border-b flex select-none items-center gap-2">
                 <h1 className="text-base md:text-lg font-bold shrink-0 leading-none">
                     <span style={{ color: "#FF5F05" }}>illini</span>


### PR DESCRIPTION
This PR improves the map-off view layout so that the list view is constrained to a readable maximum width on wide displays instead of stretching full-width.

### Before

When toggling off the map view, the sidebar stretched edge-to-edge across the entire screen, causing search inputs, facility cards, and room status badges to spread out excessively on wide monitors.

### After

The map-off container is centered with `max-w-3xl` (768px), framed by subtle side borders and a neutral background canvas on desktop viewports. Mobile viewports continue to fill the full screen width.

### Change type

- [x] `improvement`

### Test plan

1. Open the app on desktop.
2. Toggle the map off from the options menu.
3. Verify the facility and room list is centered with a max width of 768px (`max-w-3xl`) and framed with subtle side borders.
4. Resize the viewport to mobile width and verify the list fills the full screen width without extra borders or horizontal overflow.
5. Toggle the map back on and verify the split view functions as expected.

- [x] Unit tests

### Release notes

- Improve map-off view layout by centering the list with a maximum width on large screens

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +10 / -4   |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout when the map is hidden by centering content on a muted background.
  * Added a constrained, bordered, and subtly shadowed sidebar presentation.
  * Updated responsive sidebar borders and ordering for clearer separation between map and sidebar views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->