### PR TITLE
refactor(client): modernize React state synchronization

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,8 +31,6 @@ export default tseslint.config(
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-require-imports": "off",
-      "react-hooks/immutability": "off",
-      "react-hooks/set-state-in-effect": "off",
       "react-refresh/only-export-components": "off",
     },
   },

--- a/src/components/AcademicRoomDetailLoader.tsx
+++ b/src/components/AcademicRoomDetailLoader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { TimelineSchedule } from "@/components/TimelineSchedule";
 import { RoomScheduleBlock } from "@/types";
@@ -28,17 +28,16 @@ const fetchScheduleForDate = async (
   return response.json();
 };
 
-const AcademicRoomDetailLoader: React.FC<AcademicRoomDetailLoaderProps> = ({
+interface AcademicRoomScheduleLoaderProps extends AcademicRoomDetailLoaderProps {
+  initialDate: string;
+}
+
+function AcademicRoomScheduleLoader({
   buildingId,
   roomNumber,
-}) => {
-  const { selectedDateTime } = useDateTimeContext();
-  const [selectedDate, setSelectedDate] = useState(selectedDateTime.date);
-
-  // Sync if global context date changes
-  useEffect(() => {
-    setSelectedDate(selectedDateTime.date);
-  }, [selectedDateTime.date]);
+  initialDate,
+}: AcademicRoomScheduleLoaderProps) {
+  const [selectedDate, setSelectedDate] = useState(initialDate);
 
   const {
     data: scheduleData,
@@ -79,6 +78,22 @@ const AcademicRoomDetailLoader: React.FC<AcademicRoomDetailLoaderProps> = ({
       onDateChange={setSelectedDate}
     />
   );
-};
+}
+
+function AcademicRoomDetailLoader({
+  buildingId,
+  roomNumber,
+}: AcademicRoomDetailLoaderProps) {
+  const { selectedDateTime } = useDateTimeContext();
+
+  return (
+    <AcademicRoomScheduleLoader
+      key={selectedDateTime.date}
+      buildingId={buildingId}
+      roomNumber={roomNumber}
+      initialDate={selectedDateTime.date}
+    />
+  );
+}
 
 export default AcademicRoomDetailLoader;

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -56,9 +56,6 @@ export default function FacilityMap({
       );
     };
 
-    setIsMapLoaded(false);
-    setMapError(null);
-
     const config = getClientConfig();
     const styleUrl = config.mapboxStyleUrl;
     const token = config.mapboxAccessToken;
@@ -67,6 +64,8 @@ export default function FacilityMap({
         "Mapbox style and access token are not configured.",
       );
       recordMapOutcome("missing_configuration");
+      // Without this update, missing credentials leave the loading overlay active.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setMapError("The map is not configured.");
       return;
     }

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -35,12 +35,6 @@ function Calendar({
     startOfMonth(selected ?? new Date()),
   );
 
-  React.useEffect(() => {
-    if (selected) {
-      setCurrentMonth(startOfMonth(selected));
-    }
-  }, [selected]);
-
   const days = React.useMemo(() => {
     const monthStart = startOfMonth(currentMonth);
     const monthEnd = endOfMonth(monthStart);


### PR DESCRIPTION
This PR improves React state synchronization so date changes do not require effects that immediately copy one state value into another.

### Before

The academic room schedule and calendar mirrored date selections through effects. The relevant React hook protections were disabled globally, allowing similar synchronization effects and mutation issues to pass linting.

### After

Room schedule state resets through component identity when the global date changes, while calendar navigation remains local state initialized from the selected date. The modern hook immutability and effect-state rules are enabled globally, with one documented exception for the imperative Mapbox initialization lifecycle.

### Change type

- [x] `improvement`

### Test plan

- [x] Existing unit tests — 121 passing
- [x] ESLint
- [x] TypeScript
- [x] Production build

### Code changes

| Section | LOC change |
| --- | --- |
| Apps | +28 / -20 |
| Config/tooling | +0 / -2 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schedule loading when the selected date changes, ensuring fresh data is displayed.
  * Fixed the map’s unavailable-configuration state so users see an appropriate error instead of a lingering loading indicator.
  * Prevented the calendar from unexpectedly jumping back to the selected month while navigating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->