### PR TITLE
build(toolchain): upgrade Bun to 1.4.1

### DIFF
--- a/.github/workflows/web-checks.yml
+++ b/.github/workflows/web-checks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.1
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.0-alpine AS dependencies
+FROM oven/bun:1.4.1-alpine AS dependencies
 WORKDIR /app
 
 COPY package.json bun.lock ./
@@ -11,7 +11,7 @@ ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 COPY . .
 RUN bun run build
 
-FROM oven/bun:1.4.0-alpine AS runtime
+FROM oven/bun:1.4.1-alpine AS runtime
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.4.0",
+  "packageManager": "bun@1.4.1",
   "engines": {
-    "bun": ">=1.4.0",
+    "bun": ">=1.4.1",
     "node": ">=22.12.0"
   },
   "scripts": {

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "framework": "vite",
   "bunVersion": "1.4.x",
   "buildCommand": "bun run build",
-  "installCommand": "npx --yes bun@1.4.0 install --frozen-lockfile",
+  "installCommand": "npx --yes bun@1.4.1 install --frozen-lockfile",
   "outputDirectory": "dist/client",
   "functions": {
     "api/[...route].ts": {


### PR DESCRIPTION
In order to adopt the latest bugfixes and runtime enhancements from the Bun v1.4.1 release, this PR upgrades Bun across the application configuration, Docker containers, Vercel deployments, and CI workflows.

### Change type

- [x] `other`

### Test plan

1. Verified local Bun runtime is `v1.4.1`.
2. Verified `bun install --frozen-lockfile` cleanly resolves dependencies with no lockfile changes.
3. Verified `bun run check` passes linting, all 123 tests across 27 files, Vite production build, and TypeScript checks.
4. Verified `docker build` succeeds against `oven/bun:1.4.1-alpine`.

- [x] Unit tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Config/tooling  | +6 / -6    |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Bun runtime and package manager version to 1.4.1.
  * Standardized Bun 1.4.1 across local builds, container images, automated checks, and deployments.
  * Preserved frozen-lockfile installation behavior for consistent dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->