### PR TITLE
ci(workflow): retry Tableau daily events step on failure

### DIFF
--- a/.github/workflows/tableau-daily-events.yml
+++ b/.github/workflows/tableau-daily-events.yml
@@ -17,7 +17,7 @@ jobs:
   update-daily-events:
     name: Update daily events
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 300
 
     defaults:
       run:
@@ -55,15 +55,22 @@ jobs:
           --schedule "5 0 * * *"
           --timezone "America/Chicago"
           --checkin-margin 415
-          --max-runtime 30
+          --max-runtime 300
 
       - name: Update Tableau daily events
-        run: >-
-          python sentry_monitor.py run-stage
-          --monitor-slug tableau-daily-events
-          --stage update-daily-events
-          --label "Update Tableau daily events"
-          -- python cron/tableau_dailyevents_scraper.py
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 8
+          retry_wait_seconds: 900
+          shell: bash
+          command: >-
+            cd data-pipeline &&
+            python sentry_monitor.py run-stage
+            --monitor-slug tableau-daily-events
+            --stage update-daily-events
+            --label "Update Tableau daily events"
+            -- python cron/tableau_dailyevents_scraper.py
 
       - name: Complete Sentry monitor
         if: ${{ always() }}


### PR DESCRIPTION
This PR improves the Tableau daily refresh workflow by adding automated step retries on failure.

### Before

The workflow attempted to scrape Tableau daily events once. If connection timeouts or transient network errors occurred during data extraction, the step failed immediately, leaving the database stale until manual re-run or the next scheduled cron run.

### After

The workflow uses `nick-fields/retry@v4` (`v4.0.0`, Node 24 runtime, pinned by SHA `ad984534de44a9489a53aefd81eb77f87c70dc60`) to retry up to 8 attempts with a 15-minute backoff (`retry_wait_seconds: 900`) between attempts. The job `timeout-minutes` and Sentry cron monitor `--max-runtime` are set to 300 minutes (5 hours), allowing automated retries to continue overnight and conclude before the 7:00 AM Central freshness deadline.

### Change type

- [x] `improvement`

### Test plan

- [x] Validate YAML syntax with PyYAML parser
- [x] Verify Node 24 compatibility for `nick-fields/retry@v4` on GitHub Actions runners
- [x] Run repository verification suite (`bun run check`)

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +15 / -8   |

Refs ILLINISPOTS-3