### PR TITLE
fix(pipeline): treat empty Tableau snapshot as success

### DIFF
--- a/data-pipeline/cron/tableau_dailyevents_scraper.py
+++ b/data-pipeline/cron/tableau_dailyevents_scraper.py
@@ -133,8 +133,9 @@ def load_to_postgres(df):
         df (DataFrame): Pandas DataFrame containing events data.
 
     Returns:
-        dict | bool: Inserted and unloadable event counts, or False when no
-            events were inserted.
+        dict | bool: Inserted and unloadable event counts, or False when the
+            database insert itself failed. An empty validated snapshot is
+            success with zero inserted events so stale events are cleared.
     """
     supabase = get_supabase_client()
 
@@ -229,8 +230,11 @@ def load_to_postgres(df):
             print(f"Error inserting events: {str(e)}")
             return False
     else:
-        print("No valid events to insert")
-        return False
+        print("No valid events to insert; cleared snapshot remains empty")
+        return {
+            "inserted_events": 0,
+            "unloadable_events": len(invalid_events),
+        }
 
 def main():
     """Main function to scrape daily events and load them to PostgreSQL.
@@ -247,8 +251,8 @@ def main():
 
     print("Step 2: Load data to PostgreSQL")
     load_counts = load_to_postgres(events)
-    if not load_counts:
-        raise RuntimeError("Failed Step 2: No valid events were inserted")
+    if load_counts is False:
+        raise RuntimeError("Failed Step 2: Error inserting events")
 
     print("Finished Step 2")
     


### PR DESCRIPTION
This PR fixes a bug where an empty Tableau daily-events snapshot failed the pipeline with "RuntimeError: Failed Step 2: No valid events were inserted".

### Before

load_to_postgres returned False when there was nothing valid to insert, so main raised and the job exited non-zero before the cache refresh and gauge emission. That turned legitimate empty days into Sentry errors plus needless retries.

### After

An empty validated snapshot returns zero counts, so the job clears stale events, refreshes the cache, emits gauges, and exits 0. Only a real database insert failure returns False and raises.

### Change type

- [x] bugfix

### Test plan

- Mocked supabase: empty df returns {inserted_events: 0, unloadable_events: 0} and does not raise
- Mocked supabase: all-unknown rooms returns {inserted_events: 0, unloadable_events: 1}
- Mocked supabase: insert exception still returns False so main raises
- python3 -m py_compile passes

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix empty Tableau daily-events snapshots failing the pipeline

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Core code | +0 / -0 |
| Apps | +0 / -0 |
| Config/tooling | +10 / -6 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty validated snapshots are now treated as successful runs with zero inserted events.
  - Empty results no longer incorrectly trigger a runtime failure.
  - Database insertion failures continue to be reported as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->