### PR TITLE
feat(pipeline): Add job summary to Tableau daily events

### DIFF
--- a/data-pipeline/README.MD
+++ b/data-pipeline/README.MD
@@ -67,6 +67,7 @@ This directory contains scripts for collecting and processing UIUC course and bu
    - Scrapes daily event data from [Tableau](https://tableau.admin.uillinois.edu/views/DailyEventSummary/DailyEvents) and loads it into PostgreSQL
    - Updates the `daily_events` table with current day's events
    - Runs daily through [the GitHub Actions workflow](../.github/workflows/tableau-daily-events.yml), and can also be started manually from the Actions tab
+   - Emits a GitHub Actions job-summary table with source rows, valid rows, inserted events, and skipped events
    - The repository must define `SUPABASE_URL` and `SUPABASE_SECRET_KEY` as GitHub Actions repository secrets; the key must be allowed to read `rooms`, replace `daily_events`, and invoke `refresh_room_availability_cache`
 
 ## Data Flow Diagram

--- a/data-pipeline/cron/tableau_dailyevents_scraper.py
+++ b/data-pipeline/cron/tableau_dailyevents_scraper.py
@@ -17,6 +17,39 @@ TABLEAU_RETRY_BACKOFF_SECONDS = 5
 TABLEAU_RETRY_MAX_BACKOFF_SECONDS = 240
 
 
+def write_github_summary(
+    tableau_rows,
+    valid_rows,
+    inserted_events,
+    invalid_timestamp_events,
+    unloadable_events,
+    skipped_events,
+) -> None:
+    summary_path = os.getenv("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    with open(summary_path, "a") as summary:
+        summary.write("\n## Tableau daily events\n\n")
+        if skipped_events == 0:
+            summary.write(
+                f"✅ Loaded {inserted_events} daily event(s) "
+                f"from {tableau_rows} Tableau row(s).\n\n"
+            )
+        else:
+            summary.write(
+                f"⚠️ Loaded {inserted_events} daily event(s); "
+                f"skipped {skipped_events} of {tableau_rows} Tableau row(s).\n\n"
+            )
+        summary.write("| Metric | Count |\n| --- | --- |\n")
+        summary.write(f"| Tableau source rows | {tableau_rows} |\n")
+        summary.write(f"| Valid timestamp rows | {valid_rows} |\n")
+        summary.write(f"| Inserted daily events | {inserted_events} |\n")
+        summary.write(f"| Invalid timestamps | {invalid_timestamp_events} |\n")
+        summary.write(f"| Unloadable events | {unloadable_events} |\n")
+        summary.write(f"| Total skipped | {skipped_events} |\n")
+
+
 def get_supabase_client():
     """Initialize and return Supabase client.
 
@@ -267,16 +300,26 @@ def main():
 
     invalid_timestamp_events = events.attrs.get("invalid_timestamp_events", 0)
     unloadable_events = load_counts["unloadable_events"]
+    tableau_rows = events.attrs.get("tableau_rows", len(events))
+    valid_rows = len(events)
+    inserted_events = load_counts["inserted_events"]
+    skipped_events = invalid_timestamp_events + unloadable_events
+    write_github_summary(
+        tableau_rows,
+        valid_rows,
+        inserted_events,
+        invalid_timestamp_events,
+        unloadable_events,
+        skipped_events,
+    )
     emit_gauges(
         {
-            "pipeline.data.tableau_rows": events.attrs.get("tableau_rows", len(events)),
-            "pipeline.data.valid_timestamp_events": len(events),
-            "pipeline.database.daily_events": load_counts["inserted_events"],
+            "pipeline.data.tableau_rows": tableau_rows,
+            "pipeline.data.valid_timestamp_events": valid_rows,
+            "pipeline.database.daily_events": inserted_events,
             "pipeline.data.invalid_timestamp_events": invalid_timestamp_events,
             "pipeline.data.unloadable_events": unloadable_events,
-            "pipeline.data.skipped_events": (
-                invalid_timestamp_events + unloadable_events
-            ),
+            "pipeline.data.skipped_events": skipped_events,
         },
         {"pipeline": "tableau-daily-events"},
     )


### PR DESCRIPTION
In order to match the Course Explorer weekly run's auto-generated summary, this PR adds a GitHub job-summary table to the Tableau daily events pipeline.

The scraper writes source rows, valid rows, inserted events, and skipped counts to GITHUB_STEP_SUMMARY on success, reusing the same numbers already sent to Sentry. No workflow change needed since it runs inside the existing step, and it is a no-op locally when the env var is unset.

### Change type

- [x] `feature`

### Test plan

- Verified write_github_summary with temp summary file for 0-skipped and skipped cases, plus no-env no-op
- py_compile passes

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +49 / -6   |
| Documentation   | +1 / -0    |
