### PR TITLE
chore(lint): enable oxlint perf category

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,7 +7,8 @@
     "oxc"
   ],
   "categories": {
-    "correctness": "error"
+    "correctness": "error",
+    "perf": "warn"
   },
   "env": {
     "builtin": true

--- a/src/components/TimelineSchedule.tsx
+++ b/src/components/TimelineSchedule.tsx
@@ -210,15 +210,18 @@ export const TimelineSchedule: React.FC<TimelineScheduleProps> = ({
 
             <div className="relative h-12 w-full overflow-hidden rounded border border-border/60 bg-muted/30">
               {Array.from({ length: timeline.totalHours - 1 }).map(
-                (_, index) => (
-                  <div
-                    key={index}
-                    className="pointer-events-none absolute bottom-0 top-0 border-r border-border/25"
-                    style={{
-                      left: `${((index + 1) / timeline.totalHours) * 100}%`,
-                    }}
-                  />
-                ),
+                (_, index) => {
+                  const left = `${((index + 1) / timeline.totalHours) * 100}%`;
+                  return (
+                    <div
+                      key={left}
+                      className="pointer-events-none absolute bottom-0 top-0 border-r border-border/25"
+                      style={{
+                        left,
+                      }}
+                    />
+                  );
+                },
               )}
 
               <TooltipProvider delayDuration={50}>

--- a/src/components/facilities/FacilityAccordionItem.tsx
+++ b/src/components/facilities/FacilityAccordionItem.tsx
@@ -5,7 +5,7 @@ import {
   Facility,
   RoomStatus,
 } from "@/types";
-import { FilterCriteria, isRoomAvailable } from "@/utils/filterUtils";
+import { FilterCriteria, EMPTY_FILTER_CRITERIA, isRoomAvailable } from "@/utils/filterUtils";
 import {
   STATUS_BADGE_STYLES,
   getFacilityAvailabilityBadgeStyle,
@@ -27,7 +27,7 @@ export const FacilityAccordionItem: React.FC<FacilityAccordionItemProps> = memo(
   ({
     facility,
     isExpanded,
-    filterCriteria = {},
+    filterCriteria = EMPTY_FILTER_CRITERIA,
   }) => {
     const posthog = usePostHog();
 

--- a/src/components/facilities/FacilityListView.tsx
+++ b/src/components/facilities/FacilityListView.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from "react";
 import { Facility } from "@/types";
-import { FilterCriteria } from "@/utils/filterUtils";
+import { FilterCriteria, EMPTY_FILTER_CRITERIA } from "@/utils/filterUtils";
 import { Button } from "@/components/ui/button";
 import { Accordion } from "@/components/ui/accordion";
 import { FacilityAccordionItem } from "./FacilityAccordionItem";
@@ -24,7 +24,7 @@ export const FacilityListView: React.FC<FacilityListViewProps> = memo(
     academicFacilities,
     expandedFacilityIds,
     onExpandedFacilityIdsChange,
-    filterCriteria = {},
+    filterCriteria = EMPTY_FILTER_CRITERIA,
     isLibraryFetching = false,
     isAcademicLoading = false,
     error = null,

--- a/src/components/facilities/FacilityRoomView.tsx
+++ b/src/components/facilities/FacilityRoomView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, memo } from "react";
 import { Facility, FacilityType } from "@/types";
-import { FilterCriteria, isRoomAvailable } from "@/utils/filterUtils";
+import { FilterCriteria, EMPTY_FILTER_CRITERIA, isRoomAvailable } from "@/utils/filterUtils";
 import { getLibraryHoursMessage } from "@/utils/libraryHours";
 import { formatTimeForDisplay } from "@/utils/time";
 import { RoomRow } from "./RoomRow";
@@ -14,7 +14,7 @@ interface FacilityRoomViewProps {
 type RoomTab = "available" | "occupied" | "all";
 
 export const FacilityRoomView: React.FC<FacilityRoomViewProps> = memo(
-  ({ facility, filterCriteria = {} }) => {
+  ({ facility, filterCriteria = EMPTY_FILTER_CRITERIA }) => {
     const isAcademic = facility.type === FacilityType.ACADEMIC;
     const [activeTab, setActiveTab] = useState<RoomTab>("available");
     const [expandedRoomId, setExpandedRoomId] = useState<string | null>(null);

--- a/src/components/ui/HybridTooltip.tsx
+++ b/src/components/ui/HybridTooltip.tsx
@@ -1,8 +1,10 @@
 import {
   PropsWithChildren,
   createContext,
+  useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import { useMediaQuery } from "@/hooks/use-media-query";
@@ -42,22 +44,28 @@ export const usePopoverOpen = () => useContext(PopoverOpenContext);
 
 export const HybridTooltip = (props: TooltipProps & PopoverProps) => {
   const isTouch = useTouch();
-  const [open, setOpen] = useState(props.open || false);
+  const { open: controlledOpen, onOpenChange: controlledOnOpenChange } = props;
+  const [open, setOpen] = useState(controlledOpen || false);
 
-  const isControlled = props.open !== undefined;
-  const isOpen = isControlled ? props.open : open;
-  const onOpenChange = (value: boolean) => {
-    if (isControlled) {
-      props.onOpenChange?.(value);
-    } else {
-      setOpen(value);
-    }
-  };
+  const isControlled = controlledOpen !== undefined;
+  const isOpen = isControlled ? controlledOpen : open;
+  const onOpenChange = useCallback(
+    (value: boolean) => {
+      if (isControlled) {
+        controlledOnOpenChange?.(value);
+      } else {
+        setOpen(value);
+      }
+    },
+    [isControlled, controlledOnOpenChange],
+  );
+  const popoverOpenValue = useMemo(
+    () => ({ open: isOpen, setOpen: onOpenChange }),
+    [isOpen, onOpenChange],
+  );
 
   return (
-    <PopoverOpenContext.Provider
-      value={{ open: isOpen, setOpen: onOpenChange }}
-    >
+    <PopoverOpenContext.Provider value={popoverOpenValue}>
       {isTouch ? (
         <Popover {...props} open={isOpen} onOpenChange={onOpenChange} />
       ) : (

--- a/src/contexts/DateTimeContext.tsx
+++ b/src/contexts/DateTimeContext.tsx
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
   ReactNode,
 } from "react";
@@ -94,16 +95,25 @@ export function DateTimeProvider({ children }: { children: ReactNode }) {
     };
   }, [state.isLive]);
 
+  const value = useMemo<DateTimeContextType>(
+    () => ({
+      selectedDateTime: state.selectedDateTime,
+      liveNow: state.liveNow,
+      setSelectedDateTime,
+      isCurrentDateTime: state.isLive,
+      resetToCurrentDateTime,
+    }),
+    [
+      state.selectedDateTime,
+      state.liveNow,
+      state.isLive,
+      setSelectedDateTime,
+      resetToCurrentDateTime,
+    ],
+  );
+
   return (
-    <DateTimeContext.Provider
-      value={{
-        selectedDateTime: state.selectedDateTime,
-        liveNow: state.liveNow,
-        setSelectedDateTime,
-        isCurrentDateTime: state.isLive,
-        resetToCurrentDateTime,
-      }}
-    >
+    <DateTimeContext.Provider value={value}>
       {children}
     </DateTimeContext.Provider>
   );

--- a/src/server/observability.e2e.test.ts
+++ b/src/server/observability.e2e.test.ts
@@ -40,7 +40,9 @@ async function waitFor(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    // oxlint-disable-next-line no-await-in-loop -- polling helper: each check must run sequentially after the previous one
     if (await predicate()) return;
+    // oxlint-disable-next-line no-await-in-loop -- polling delay must run sequentially between checks; Promise.all does not apply
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error(`Condition was not met within ${timeoutMs}ms`);

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -7,6 +7,9 @@ export interface FilterCriteria {
   nowMinutes?: number;
 }
 
+/** Shared default for optional `filterCriteria` props: a fresh `{}` per render would break memoization. */
+export const EMPTY_FILTER_CRITERIA: FilterCriteria = {};
+
 export const isRoomAvailable = (
   room: FacilityRoom,
   criteria: FilterCriteria,


### PR DESCRIPTION
In order to catch render-performance regressions in CI, this PR turns on oxlint's perf category (as warn) and fixes the 8 findings it surfaces, so lint stays clean.

The fixes are small behavior-preserving ones: the date-time and tooltip popover contexts now memoize their provider values instead of constructing a fresh object each render, the three memoized facility components share an EMPTY_FILTER_CRITERIA default instead of `={}`, and the static timeline dividers are keyed by position. The polling helper's sequential awaits (where Promise.all does not apply) get targeted disable comments.

I left the separate react-perf plugin off: it flags every inline arrow-function prop and is too noisy for this codebase.

### Test plan

- `bun run lint` clean, including `oxlint -D perf --deny-warnings`
- `bun run typecheck` clean
- `bun test` — 123 pass, 0 fail