### PR TITLE
chore(lint): enable oxlint style category

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,7 +8,8 @@
   ],
   "categories": {
     "correctness": "error",
-    "perf": "warn"
+    "perf": "warn",
+    "style": "warn"
   },
   "env": {
     "builtin": true
@@ -41,7 +42,30 @@
     "typescript/no-namespace": "error",
     "typescript/no-require-imports": "error",
     "typescript/no-unnecessary-type-constraint": "error",
-    "typescript/no-unsafe-function-type": "error"
+    "typescript/no-unsafe-function-type": "error",
+    "typescript/consistent-type-imports": ["warn", { "fixStyle": "inline-type-imports" }],
+    "eslint/capitalized-comments": "off",
+    "eslint/func-style": "off",
+    "eslint/id-length": "off",
+    "eslint/init-declarations": "off",
+    "eslint/max-params": "off",
+    "eslint/max-statements": "off",
+    "eslint/no-continue": "off",
+    "eslint/no-magic-numbers": "off",
+    "eslint/no-nested-ternary": "off",
+    "eslint/no-ternary": "off",
+    "eslint/one-var": "off",
+    "eslint/sort-imports": "off",
+    "eslint/sort-keys": "off",
+    "react/function-component-definition": "off",
+    "react/jsx-max-depth": "off",
+    "react/jsx-props-no-spreading": "off",
+    "unicorn/filename-case": "off",
+    "unicorn/no-nested-ternary": "off",
+    "unicorn/no-null": "off",
+    "unicorn/numeric-separators-style": "off",
+    "unicorn/prefer-global-this": "off",
+    "unicorn/switch-case-braces": "off"
   },
   "overrides": [
     {

--- a/src/client/config.ts
+++ b/src/client/config.ts
@@ -1,6 +1,6 @@
 import type { PublicClientConfig } from "@/types";
 
-export type { PublicClientConfig };
+export type { PublicClientConfig } from "@/types";
 
 declare global {
   interface Window {
@@ -8,7 +8,7 @@ declare global {
   }
 }
 
-export type FallbackClientEnvironment = {
+export interface FallbackClientEnvironment {
   readonly VITE_APP_ENV?: string;
   readonly VITE_MAPBOX_ACCESS_TOKEN?: string;
   readonly VITE_MAPBOX_STYLE_URL?: string;
@@ -16,7 +16,7 @@ export type FallbackClientEnvironment = {
   readonly VITE_PUBLIC_POSTHOG_PROJECT_TOKEN?: string;
   readonly VITE_PUBLIC_POSTHOG_HOST?: string;
   readonly MODE?: string;
-};
+}
 
 export function getClientConfig(
   fallbackEnv: FallbackClientEnvironment = import.meta.env,

--- a/src/client/observability.ts
+++ b/src/client/observability.ts
@@ -10,7 +10,7 @@ export const CLIENT_TRACE_PROPAGATION_TARGETS = [
 
 export function shouldCreateClientRequestSpan(url: string): boolean {
   try {
-    const hostname = new URL(url, "https://illinispots.local").hostname;
+    const {hostname} = new URL(url, "https://illinispots.local");
     return hostname !== "mapbox.com" && !hostname.endsWith(".mapbox.com");
   } catch {
     return true;
@@ -18,11 +18,11 @@ export function shouldCreateClientRequestSpan(url: string): boolean {
 }
 
 export function initializeClientObservability(router: AnyRouter): void {
-  if (Sentry.isInitialized()) return;
+  if (Sentry.isInitialized()) {return;}
 
   const config = getClientConfig();
-  if (config.appEnv === "development") return;
-  if (!config.sentryDsn) return;
+  if (config.appEnv === "development") {return;}
+  if (!config.sentryDsn) {return;}
 
   Sentry.init({
     dsn: config.sentryDsn,
@@ -38,4 +38,4 @@ export function initializeClientObservability(router: AnyRouter): void {
   });
 }
 
-export { Sentry };
+export * as Sentry from "@sentry/react";

--- a/src/client/providers.tsx
+++ b/src/client/providers.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@/contexts/ThemeContext";
 import { TouchProvider } from "@/components/ui/HybridTooltip";
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  // oxlint-disable-next-line react/hook-use-state -- lazy singleton instance, the setter is intentionally unused
   const [queryClient] = React.useState(
     () =>
       new QueryClient({

--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -15,7 +15,7 @@ import {
   type CampusDateTime,
 } from "@/utils/time";
 import LeftSidebar from "@/components/left";
-import { FacilityStatus, FacilityType } from "@/types";
+import type { FacilityStatus, FacilityType } from "@/types";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
 import {
   recordInitialLoadMilestone,
@@ -189,13 +189,13 @@ const IlliniSpotsPage: React.FC = () => {
   }, [academicData, isCurrentDateTime, libraryData, liveNow]);
 
   useEffect(() => {
-    if (!isCurrentDateTime) return;
+    if (!isCurrentDateTime) {return;}
 
     let timeoutId: number | undefined;
     let cancelled = false;
 
     const scheduleNextRefresh = () => {
-      if (cancelled) return;
+      if (cancelled) {return;}
 
       timeoutId = window.setTimeout(() => {
         timeoutId = undefined;
@@ -208,7 +208,7 @@ const IlliniSpotsPage: React.FC = () => {
     scheduleNextRefresh();
     return () => {
       cancelled = true;
-      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+      if (timeoutId !== undefined) {window.clearTimeout(timeoutId);}
     };
   }, [isCurrentDateTime, refetchAcademic, refetchLibrary]);
 
@@ -254,7 +254,7 @@ const IlliniSpotsPage: React.FC = () => {
             <FacilityMap
               facilityData={facilityData || null}
               onMarkerClick={handleMarkerClick}
-              trackInitialLoad={true}
+              trackInitialLoad
             />
           </Suspense>
         </div>

--- a/src/components/AcademicRoomDetailLoader.tsx
+++ b/src/components/AcademicRoomDetailLoader.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { TimelineSchedule } from "@/components/TimelineSchedule";
-import { RoomScheduleBlock } from "@/types";
+import type { RoomScheduleBlock } from "@/types";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
 
 interface AcademicRoomDetailLoaderProps {

--- a/src/components/AddFavoritesDialog.tsx
+++ b/src/components/AddFavoritesDialog.tsx
@@ -11,8 +11,8 @@ import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Switch } from '@/components/ui/switch';
 import { Search } from 'lucide-react';
-import { Facility, FacilityStatus, FacilityType } from '@/types';
-import { FavoriteItem } from '@/hooks/useFavorites';
+import { type Facility, type FacilityStatus, FacilityType } from '@/types';
+import type { FavoriteItem } from '@/hooks/useFavorites';
 import { searchFacilities } from '@/utils/searchUtils';
 
 interface AddFavoritesDialogProps {
@@ -34,15 +34,15 @@ export const AddFavoritesDialog: React.FC<AddFavoritesDialogProps> = ({
     const [searchTerm, setSearchTerm] = useState("");
 
     const facilities = useMemo(() => {
-        if (!facilityData) return [];
+        if (!facilityData) {return [];}
         return Object.values(facilityData.facilities).sort((a, b) =>
             a.name.localeCompare(b.name)
         );
     }, [facilityData]);
 
-    const filteredFacilities = useMemo(() => {
-        return searchFacilities(facilities, searchTerm);
-    }, [facilities, searchTerm]);
+    const filteredFacilities = useMemo(() => 
+        searchFacilities(facilities, searchTerm)
+    , [facilities, searchTerm]);
 
     const isFavorite = (id: string) => favorites.some(f => f.id === id);
 

--- a/src/components/FavoritesSection.tsx
+++ b/src/components/FavoritesSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
-import { FavoriteItem } from '@/hooks/useFavorites';
-import { Facility, FacilityStatus } from '@/types';
+import type { FavoriteItem } from '@/hooks/useFavorites';
+import type { Facility, FacilityStatus } from '@/types';
 import {
   STATUS_BADGE_STYLES,
   getFacilityAvailabilityBadgeStyle,
@@ -30,7 +30,7 @@ export const FavoritesSection: React.FC<FavoritesSectionProps> = ({
   }
 
   const getFacilityData = (favoriteId: string): Facility | null => {
-    if (!facilityData) return null;
+    if (!facilityData) {return null;}
     return Object.values(facilityData.facilities).find(
       facility => facility.id === favoriteId
     ) || null;

--- a/src/components/RoomBadge.tsx
+++ b/src/components/RoomBadge.tsx
@@ -29,7 +29,7 @@ export function getFacilityAvailabilityBadgeStyle(
   isOpen: boolean,
   availableCount: number,
 ): string {
-  if (!isOpen) return STATUS_BADGE_STYLES.closed;
+  if (!isOpen) {return STATUS_BADGE_STYLES.closed;}
   return availableCount > 0
     ? STATUS_BADGE_STYLES[RoomStatus.AVAILABLE]
     : STATUS_BADGE_STYLES[RoomStatus.OCCUPIED];
@@ -62,13 +62,13 @@ const getStatusText = (
 };
 
 export const RoomBadge: React.FC<RoomBadgeProps> = memo(
-  ({ status, facilityType }) => {
-    return (
+  ({ status, facilityType }) => 
+    (
       <Badge variant="outline" className={badgeStyles[status]}>
         {getStatusText(status, facilityType)}
       </Badge>
-    );
-  },
+    )
+  ,
 );
 
 RoomBadge.displayName = "RoomBadge";

--- a/src/components/RoomSearchResultCard.tsx
+++ b/src/components/RoomSearchResultCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { usePostHog } from "@posthog/react";
-import { SearchResultRoom } from "@/utils/searchUtils";
-import { AcademicRoom, FacilityType, LibraryRoom, RoomStatus } from "@/types";
+import type { SearchResultRoom } from "@/utils/searchUtils";
+import { type AcademicRoom, type LibraryRoom, FacilityType, RoomStatus } from "@/types";
 import { RoomBadge } from "@/components/RoomBadge";
 import { formatDuration } from "@/utils/format";
 import { formatTimeForDisplay } from "@/utils/time";

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { performSearch } from "@/utils/searchUtils";
-import { Facility, FacilityStatus } from "@/types";
-import { FilterCriteria } from "@/utils/filterUtils";
+import type { Facility, FacilityStatus } from "@/types";
+import type { FilterCriteria } from "@/utils/filterUtils";
 import { RoomSearchResultCard } from "@/components/RoomSearchResultCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -32,18 +32,18 @@ export const SearchResults: React.FC<SearchResultsProps> = ({
   isLibraryLoading = false,
 }) => {
   const facilitiesList = useMemo<Facility[]>(() => {
-    if (!facilityData) return [];
+    if (!facilityData) {return [];}
     return Object.values(facilityData.facilities);
   }, [facilityData]);
 
-  const rooms = useMemo(() => {
-    return performSearch(
+  const rooms = useMemo(() => 
+    performSearch(
       facilitiesList,
       searchTerm,
       filterCriteria,
       hasActiveFilters,
-    );
-  }, [facilitiesList, searchTerm, filterCriteria, hasActiveFilters]);
+    )
+  , [facilitiesList, searchTerm, filterCriteria, hasActiveFilters]);
 
   const isDataIncomplete = isLoading || isLibraryLoading;
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { Sun, Moon, Monitor } from "lucide-react";
 import { useTheme, type Theme } from "@/contexts/ThemeContext";
 
-const THEME_OPTIONS: Array<{
+const THEME_OPTIONS: {
   value: Theme;
   label: string;
   icon: React.ComponentType<{ size?: number }>;
-}> = [
+}[] = [
   { value: "light", label: "Light", icon: Sun },
   { value: "dark", label: "Dark", icon: Moon },
   { value: "system", label: "Auto", icon: Monitor },

--- a/src/components/TimelineSchedule.tsx
+++ b/src/components/TimelineSchedule.tsx
@@ -103,7 +103,7 @@ export const TimelineSchedule: React.FC<TimelineScheduleProps> = ({
 
   useEffect(() => {
     const container = scrollContainerRef.current;
-    if (!container) return;
+    if (!container) {return;}
 
     let targetScroll = 0;
     if (isToday) {
@@ -126,7 +126,7 @@ export const TimelineSchedule: React.FC<TimelineScheduleProps> = ({
 
   const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
     const container = scrollContainerRef.current;
-    if (!container) return;
+    if (!container) {return;}
 
     isDraggingRef.current = true;
     dragStartXRef.current = event.pageX - container.offsetLeft;
@@ -135,7 +135,7 @@ export const TimelineSchedule: React.FC<TimelineScheduleProps> = ({
 
   const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
     const container = scrollContainerRef.current;
-    if (!isDraggingRef.current || !container) return;
+    if (!isDraggingRef.current || !container) {return;}
 
     event.preventDefault();
     const currentX = event.pageX - container.offsetLeft;
@@ -230,7 +230,7 @@ export const TimelineSchedule: React.FC<TimelineScheduleProps> = ({
                     const isAvailable = block.status === "available";
                     const isPast =
                       isToday && block.end <= currentCampusTime.time;
-                    const details = block.details;
+                    const {details} = block;
                     const displayLabel =
                       details?.course ||
                       (details?.identifier && details.identifier !== "Reserved"

--- a/src/components/facilities/FacilityAccordionItem.tsx
+++ b/src/components/facilities/FacilityAccordionItem.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, memo } from "react";
 import { usePostHog } from "@posthog/react";
 import { Badge } from "@/components/ui/badge";
+import { type Facility, RoomStatus } from "@/types";
 import {
-  Facility,
-  RoomStatus,
-} from "@/types";
-import { FilterCriteria, EMPTY_FILTER_CRITERIA, isRoomAvailable } from "@/utils/filterUtils";
+  type FilterCriteria,
+  EMPTY_FILTER_CRITERIA,
+  isRoomAvailable,
+} from "@/utils/filterUtils";
 import {
   STATUS_BADGE_STYLES,
   getFacilityAvailabilityBadgeStyle,
@@ -31,15 +32,15 @@ export const FacilityAccordionItem: React.FC<FacilityAccordionItemProps> = memo(
   }) => {
     const posthog = usePostHog();
 
-    const filteredAvailableCount = useMemo(() => {
-      return Object.values(facility.rooms).filter((room) => {
+    const filteredAvailableCount = useMemo(() => 
+      Object.values(facility.rooms).filter((room) => {
         const isAvailableOrPassing =
           room.status === RoomStatus.AVAILABLE ||
           room.status === RoomStatus.PASSING_PERIOD;
 
         return isAvailableOrPassing && isRoomAvailable(room, filterCriteria);
-      }).length;
-    }, [facility.rooms, filterCriteria]);
+      }).length
+    , [facility.rooms, filterCriteria]);
 
     const handleTriggerClick = () => {
       if (!isExpanded) {

--- a/src/components/facilities/FacilityListView.tsx
+++ b/src/components/facilities/FacilityListView.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from "react";
-import { Facility } from "@/types";
-import { FilterCriteria, EMPTY_FILTER_CRITERIA } from "@/utils/filterUtils";
+import type { Facility } from "@/types";
+import { type FilterCriteria, EMPTY_FILTER_CRITERIA } from "@/utils/filterUtils";
 import { Button } from "@/components/ui/button";
 import { Accordion } from "@/components/ui/accordion";
 import { FacilityAccordionItem } from "./FacilityAccordionItem";
@@ -30,8 +30,8 @@ export const FacilityListView: React.FC<FacilityListViewProps> = memo(
     error = null,
     onRetry,
     hasActiveFilters = false,
-  }) => {
-    return (
+  }) => 
+    (
       <div className="w-full">
         {/* Library Section */}
         {libraryFacilities.length > 0 ? (
@@ -179,10 +179,10 @@ export const FacilityListView: React.FC<FacilityListViewProps> = memo(
               No results found matching your criteria
             </p>
           )}
-        <div className="h-4"></div>
+        <div className="h-4" />
       </div>
-    );
-  },
+    )
+  ,
 );
 
 FacilityListView.displayName = "FacilityListView";

--- a/src/components/facilities/FacilityRoomView.tsx
+++ b/src/components/facilities/FacilityRoomView.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useMemo, memo } from "react";
-import { Facility, FacilityType } from "@/types";
-import { FilterCriteria, EMPTY_FILTER_CRITERIA, isRoomAvailable } from "@/utils/filterUtils";
+import { type Facility, FacilityType } from "@/types";
+import {
+  type FilterCriteria,
+  EMPTY_FILTER_CRITERIA,
+  isRoomAvailable,
+} from "@/utils/filterUtils";
 import { getLibraryHoursMessage } from "@/utils/libraryHours";
 import { formatTimeForDisplay } from "@/utils/time";
 import { RoomRow } from "./RoomRow";
@@ -20,16 +24,16 @@ export const FacilityRoomView: React.FC<FacilityRoomViewProps> = memo(
     const [expandedRoomId, setExpandedRoomId] = useState<string | null>(null);
 
     // Filter and sort rooms
-    const allRooms = useMemo(() => {
-      return Object.entries(facility.rooms)
+    const allRooms = useMemo(() => 
+      Object.entries(facility.rooms)
         .filter(([, room]) => isRoomAvailable(room, filterCriteria))
         .sort(([numA], [numB]) =>
           numA.localeCompare(numB, undefined, {
             numeric: true,
             sensitivity: "base",
           }),
-        );
-    }, [facility.rooms, filterCriteria]);
+        )
+    , [facility.rooms, filterCriteria]);
 
     const { availableRooms, occupiedRooms } = useMemo(
       () => groupAcademicRooms(allRooms),

--- a/src/components/facilities/RoomRow.tsx
+++ b/src/components/facilities/RoomRow.tsx
@@ -1,10 +1,6 @@
 import React, { memo, useState } from "react";
 import { usePostHog } from "@posthog/react";
-import {
-  FacilityRoom,
-  FacilityType,
-  RoomStatus,
-} from "@/types";
+import { type FacilityRoom, FacilityType, RoomStatus } from "@/types";
 import { RoomBadge } from "@/components/RoomBadge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";

--- a/src/components/facilities/roomUtils.test.ts
+++ b/src/components/facilities/roomUtils.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { AcademicRoom, LibraryRoom, RoomStatus } from "@/types";
+import { type AcademicRoom, type LibraryRoom, RoomStatus } from "@/types";
 import {
   getRoomAvailabilityMessage,
   groupAcademicRooms,
+  type RoomEntry,
 } from "./roomUtils";
-import type { RoomEntry } from "./roomUtils";
 
 const renderAvailabilityMessage = (room: LibraryRoom) =>
   renderToStaticMarkup(getRoomAvailabilityMessage(room));

--- a/src/components/facilities/roomUtils.tsx
+++ b/src/components/facilities/roomUtils.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import {
-  AcademicRoom,
-  FacilityRoom,
-  LibraryRoom,
+  type AcademicRoom,
+  type FacilityRoom,
+  type LibraryRoom,
   RoomStatus,
 } from "@/types";
 import { formatDuration } from "@/utils/format";

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -1,7 +1,7 @@
 import React, {
+    type Dispatch,
+    type SetStateAction,
     useRef,
-    Dispatch,
-    SetStateAction,
     useEffect,
     useMemo,
     useCallback,
@@ -19,11 +19,7 @@ import {
 } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { TooltipProvider } from "@/components/ui/HybridTooltip";
-import {
-    Facility,
-    FacilityStatus,
-    FacilityType,
-} from "@/types";
+import { type Facility, type FacilityStatus, FacilityType } from "@/types";
 import {
     Map as MapIcon,
     BadgeHelp,
@@ -43,7 +39,7 @@ import RoomFilter from "@/components/RoomFilter";
 import { SearchResults } from "@/components/SearchResults";
 import { FacilityListView } from "@/components/facilities/FacilityListView";
 import { useFavorites } from "@/hooks/useFavorites";
-import { isRoomAvailable, FilterCriteria } from "@/utils/filterUtils";
+import { type FilterCriteria, isRoomAvailable } from "@/utils/filterUtils";
 import { useDateTimeContext } from "@/contexts/DateTimeContext";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import {
@@ -200,7 +196,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
         [minDuration, freeUntil, selectedDateTime],
     );
 
-    const hasActiveFilters = !!minDuration || !!freeUntil;
+    const hasActiveFilters = Boolean(minDuration) || Boolean(freeUntil);
     const isSearching = searchTerm.trim().length > 0;
     const naturalSearch = useMemo<NaturalLanguageSearchResult>(() => {
         if (naturalLanguageParser) {
@@ -225,7 +221,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     }, []);
 
     const applyNaturalSearch = useCallback(() => {
-        if (naturalSearch.error || !naturalSearch.dateTime) return;
+        if (naturalSearch.error || !naturalSearch.dateTime) {return;}
 
         posthog.capture("availability_search_applied", {
             has_location_query: Boolean(naturalSearch.locationQuery),
@@ -242,10 +238,10 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     };
 
     const facilityDataMatchesSelection = useMemo(() => {
-        if (!facilityData || isCurrentDateTime) return true;
+        if (!facilityData || isCurrentDateTime) {return true;}
 
         const responseInstant = new Date(facilityData.timestamp);
-        if (Number.isNaN(responseInstant.getTime())) return false;
+        if (Number.isNaN(responseInstant.getTime())) {return false;}
         const responseDateTime = getCampusDateTimeParts(responseInstant);
 
         return (
@@ -261,11 +257,11 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
             if (!hasActiveFilters) {
                 return facilities;
             }
-            return facilities.filter((facility) => {
-                return Object.values(facility.rooms).some((room) =>
+            return facilities.filter((facility) => 
+                Object.values(facility.rooms).some((room) =>
                     isRoomAvailable(room, filterCriteria),
-                );
-            });
+                )
+            );
         },
         [hasActiveFilters, filterCriteria],
     );
@@ -308,7 +304,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
 
     // Auto-scroll ONLY when triggered by an external source (map or favorites)
     useEffect(() => {
-        if (!scrollTargetId) return;
+        if (!scrollTargetId) {return;}
         const element = document.getElementById(`facility-${scrollTargetId}`);
         if (element) {
             element.scrollIntoView({
@@ -422,7 +418,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                     </button>
 
                                     {/* Divider */}
-                                    <div className="h-px bg-border"></div>
+                                    <div className="h-px bg-border" />
 
                                     {/* Map Toggle */}
                                     <div className="flex items-center justify-between px-3 py-2">
@@ -442,12 +438,12 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                     </div>
 
                                     {/* Divider */}
-                                    <div className="h-px bg-border"></div>
+                                    <div className="h-px bg-border" />
 
                                     {/* Appearance / Theme Switcher */}
                                     <ThemeToggle />
                                     {/* Divider */}
-                                    <div className="h-px bg-border"></div>
+                                    <div className="h-px bg-border" />
 
                                     {/* Help Section */}
                                     <Popover>
@@ -494,7 +490,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                     </a>
 
                                     {/* Divider */}
-                                    <div className="h-px bg-border"></div>
+                                    <div className="h-px bg-border" />
 
                                     {/* Data Updates Section */}
                                     <div className="px-3 py-2 text-xs text-muted-foreground space-y-1">

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect, useState, useCallback } from "react";
 import type { FeatureCollection, Point } from "geojson";
 import * as mapboxgl from "mapbox-gl/esm";
 import "mapbox-gl/dist/mapbox-gl.css";
-import {
+import type {
   MarkerData,
   MapProps,
   FacilityType,
@@ -51,11 +51,11 @@ export default function FacilityMap({
   }, [onMarkerClick, trackInitialLoad]);
 
   useEffect(() => {
-    if (!mapContainer.current) return;
+    if (!mapContainer.current) {return;}
 
     const mapLoadStartedAt = performance.now();
     const recordMapOutcome = (result: MapLoadResult) => {
-      if (mapLoadOutcomeRecorded.current) return;
+      if (mapLoadOutcomeRecorded.current) {return;}
 
       mapLoadOutcomeRecorded.current = true;
       recordMapLoadDuration(
@@ -176,7 +176,7 @@ export default function FacilityMap({
   }, []);
 
   useEffect(() => {
-    if (!map.current || !isMapLoaded || !facilityData) return;
+    if (!map.current || !isMapLoaded || !facilityData) {return;}
 
     if (activePopupRef.current) {
       activePopupRef.current.remove();
@@ -187,16 +187,12 @@ export default function FacilityMap({
       const markerEl = document.createElement("div");
       markerEl.className = "cursor-pointer";
 
-      if (!data.isOpen) {
-        markerEl.className += " h-2 w-2 rounded-full bg-gray-500 shadow-[0px_0px_4px_2px_rgba(107,114,128,0.7)]";
-      } else {
-        const hasAvailable = data.available > 0;
-        if (hasAvailable) {
-          markerEl.className += " h-2 w-2 rounded-full bg-green-400 shadow-[0px_0px_4px_2px_rgba(34,197,94,0.7)]";
-        } else {
-          markerEl.className += " h-2 w-2 rounded-full bg-red-500 shadow-[0px_0px_4px_2px_rgba(239,68,68,0.7)]";
-        }
-      }
+      const statusClass = !data.isOpen
+        ? " h-2 w-2 rounded-full bg-gray-500 shadow-[0px_0px_4px_2px_rgba(107,114,128,0.7)]"
+        : data.available > 0
+          ? " h-2 w-2 rounded-full bg-green-400 shadow-[0px_0px_4px_2px_rgba(34,197,94,0.7)]"
+          : " h-2 w-2 rounded-full bg-red-500 shadow-[0px_0px_4px_2px_rgba(239,68,68,0.7)]";
+      markerEl.className += statusClass;
 
       return markerEl;
     };
@@ -221,7 +217,7 @@ export default function FacilityMap({
       data: MarkerData,
     ) => {
       markerEl.addEventListener("mouseenter", () => {
-        if (!canShowBuildingHoverTooltip()) return;
+        if (!canShowBuildingHoverTooltip()) {return;}
 
         activePopupRef.current?.remove();
 
@@ -270,7 +266,7 @@ export default function FacilityMap({
 
     const createOrUpdateMarker = (markerKey: string, markerData: MarkerData) => {
       const existingMarker = markersRef.current.get(markerKey);
-      if (existingMarker) existingMarker.marker.remove();
+      if (existingMarker) {existingMarker.marker.remove();}
 
       const markerEl = createMarkerElement(markerData);
       const marker = new mapboxgl.Marker({ element: markerEl })
@@ -317,7 +313,7 @@ export default function FacilityMap({
             existing.data.available !== markerData.available ||
             existing.data.total !== markerData.total;
 
-          if (hasChanged) createOrUpdateMarker(markerKey, markerData);
+          if (hasChanged) {createOrUpdateMarker(markerKey, markerData);}
         }
       } else {
         createOrUpdateMarker(markerKey, markerData);
@@ -417,7 +413,7 @@ export default function FacilityMap({
             const type: FacilityType = props.type as FacilityType;
             const key = `${type}-${id}`;
             const data = markersRef.current.get(key)?.data;
-            if (!data) return;
+            if (!data) {return;}
 
             const coords =
               (feature.geometry && feature.geometry.coordinates) || null;
@@ -443,11 +439,11 @@ export default function FacilityMap({
 
         // oxlint-disable-next-line typescript/no-explicit-any
         mapRef.on("mouseenter", layerId, (e: any) => {
-          if (!canShowBuildingHoverTooltip()) return;
+          if (!canShowBuildingHoverTooltip()) {return;}
 
           mapRef.getCanvas().style.cursor = "pointer";
           const feature = e.features && e.features[0];
-          if (!feature) return;
+          if (!feature) {return;}
           showPopupForFeature(feature);
         });
 
@@ -460,7 +456,7 @@ export default function FacilityMap({
         // oxlint-disable-next-line typescript/no-explicit-any
         mapRef.on("click", layerId, (e: any) => {
           const feature = e.features && e.features[0];
-          if (!feature) return;
+          if (!feature) {return;}
           const props = feature.properties || {};
           const id: string = props.id;
           const type: FacilityType = props.type as FacilityType;
@@ -483,8 +479,8 @@ export default function FacilityMap({
           handleMarkerClick(id, type);
         });
       }
-    } catch (e) {
-      console.warn("Facility label layer setup failed:", e);
+    } catch (error) {
+      console.warn("Facility label layer setup failed:", error);
     }
 
     return () => {

--- a/src/components/ui/HybridTooltip.tsx
+++ b/src/components/ui/HybridTooltip.tsx
@@ -1,5 +1,5 @@
 import {
-  PropsWithChildren,
+  type PropsWithChildren,
   createContext,
   useCallback,
   useContext,
@@ -8,19 +8,14 @@ import {
   useState,
 } from "react";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-  TooltipProvider,
-} from "./tooltip";
+import { Tooltip, TooltipTrigger, TooltipContent } from "./tooltip";
 import { Popover, PopoverTrigger, PopoverContent } from "./popover";
-import {
+import type {
   TooltipContentProps,
   TooltipProps,
   TooltipTriggerProps,
 } from "@radix-ui/react-tooltip";
-import {
+import type {
   PopoverContentProps,
   PopoverProps,
   PopoverTriggerProps,
@@ -94,7 +89,7 @@ export const HybridTooltipContent = (
   const { open, setOpen } = usePopoverOpen();
 
   useEffect(() => {
-    if (!isTouch || !open) return;
+    if (!isTouch || !open) {return;}
 
     const handleScroll = () => {
       // close the popover on mobile scroll
@@ -115,4 +110,4 @@ export const HybridTooltipContent = (
   );
 };
 
-export { TooltipProvider };
+export { TooltipProvider } from "./tooltip";

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -107,7 +107,7 @@ function Calendar({
               type="button"
               disabled={disabled}
               onClick={() => {
-                if (disabled) return;
+                if (disabled) {return;}
                 if (!isCurrentMonth) {
                   setCurrentMonth(startOfMonth(day));
                 }

--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -46,7 +46,7 @@ function DateTimePicker({
     selectedDate !== null && parseTimeToMinutes(localTimeValue) !== null;
 
   const handleConfirm = () => {
-    if (!selectedDate || !isValidSelection) return;
+    if (!selectedDate || !isValidSelection) {return;}
     onDateTimeChange({ date: selectedDate, time: `${localTimeValue}:00` });
   };
 

--- a/src/contexts/DateTimeContext.tsx
+++ b/src/contexts/DateTimeContext.tsx
@@ -1,11 +1,11 @@
 import React, {
+  type ReactNode,
   createContext,
   useCallback,
   useContext,
   useEffect,
   useMemo,
-  useState,
-  ReactNode,
+  useState
 } from "react";
 import { getCampusDateTimeParts, type CampusDateTime } from "@/utils/time";
 
@@ -56,7 +56,7 @@ export function DateTimeProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    if (!state.isLive) return;
+    if (!state.isLive) {return;}
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const stopTimer = () => {
@@ -67,7 +67,7 @@ export function DateTimeProvider({ children }: { children: ReactNode }) {
     };
     const scheduleNextMinute = () => {
       stopTimer();
-      if (document.visibilityState !== "visible") return;
+      if (document.visibilityState !== "visible") {return;}
 
       timeoutId = setTimeout(() => {
         timeoutId = undefined;
@@ -84,7 +84,7 @@ export function DateTimeProvider({ children }: { children: ReactNode }) {
       }
     };
 
-    if (document.visibilityState === "visible") scheduleNextMinute();
+    if (document.visibilityState === "visible") {scheduleNextMinute();}
     document.addEventListener("visibilitychange", catchUpToNow);
     window.addEventListener("focus", catchUpToNow);
 

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -22,19 +22,19 @@ export const THEME_STORAGE_KEY = "theme";
 const MEDIA_QUERY = "(prefers-color-scheme: dark)";
 
 export function subscribeSystemTheme(callback: () => void) {
-  if (typeof window === "undefined") return () => {};
+  if (typeof window === "undefined") {return () => {};}
   const mq = window.matchMedia(MEDIA_QUERY);
   mq.addEventListener("change", callback);
   return () => mq.removeEventListener("change", callback);
 }
 
 export function getSystemThemeSnapshot(): ResolvedTheme {
-  if (typeof window === "undefined") return "light";
+  if (typeof window === "undefined") {return "light";}
   return window.matchMedia(MEDIA_QUERY).matches ? "dark" : "light";
 }
 
 export function getInitialTheme(): Theme {
-  if (typeof window === "undefined") return "system";
+  if (typeof window === "undefined") {return "system";}
   try {
     const stored = localStorage.getItem(THEME_STORAGE_KEY) as Theme | null;
     if (stored === "light" || stored === "dark" || stored === "system") {
@@ -47,7 +47,7 @@ export function getInitialTheme(): Theme {
 }
 
 export function applyThemeToDocument(resolved: ResolvedTheme) {
-  if (typeof document === "undefined") return;
+  if (typeof document === "undefined") {return;}
 
   const root = document.documentElement;
   root.classList.toggle("dark", resolved === "dark");

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -3,7 +3,7 @@ import * as React from "react";
 export function useMediaQuery(query: string): boolean {
   const subscribe = React.useCallback(
     (callback: () => void) => {
-      if (typeof window === "undefined") return () => {};
+      if (typeof window === "undefined") {return () => {};}
       const match = window.matchMedia(query);
       match.addEventListener("change", callback);
       return () => match.removeEventListener("change", callback);
@@ -12,7 +12,7 @@ export function useMediaQuery(query: string): boolean {
   );
 
   const getSnapshot = React.useCallback(() => {
-    if (typeof window === "undefined") return false;
+    if (typeof window === "undefined") {return false;}
     return window.matchMedia(query).matches;
   }, [query]);
 

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -30,10 +30,10 @@ function isValidFavoriteItem(item: unknown): item is FavoriteItem {
 }
 
 export function parseFavorites(raw: string | null): FavoriteItem[] {
-  if (!raw) return [];
+  if (!raw) {return [];}
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) {return [];}
     return parsed.filter(isValidFavoriteItem);
   } catch {
     return [];

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -50,7 +50,7 @@ export function createApp(dependencies: AppDependencies = {}) {
       context.req.header("x-forwarded-host") ||
       context.req.header("host") ||
       url.hostname;
-    const hostname = hostHeader.split(":")[0];
+    const [hostname] = hostHeader.split(":");
 
     const isLocal =
       hostname === "localhost" ||

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,6 +1,6 @@
 import type { PublicClientConfig } from "../types";
 
-export type { PublicClientConfig };
+export type { PublicClientConfig } from "../types";
 
 export interface SupabaseConfig {
   url: string;

--- a/src/server/html.test.ts
+++ b/src/server/html.test.ts
@@ -43,7 +43,7 @@ describe("injectClientConfig", () => {
 
     const injected = injectClientConfig(rawHtml, config);
     expect(injected).not.toContain("</script><script>");
-    expect(injected).toContain("\\u003c/script>\\u003cscript>");
+    expect(injected).toContain(String.raw`\u003c/script>\u003cscript>`);
   });
 
   it("prepends script tag if no head tag exists", () => {

--- a/src/server/html.ts
+++ b/src/server/html.ts
@@ -7,7 +7,7 @@ export function injectClientConfig(
   rawHtml: string,
   config: PublicClientConfig,
 ): string {
-  const safeJson = JSON.stringify(config).replace(/</g, "\\u003c");
+  const safeJson = JSON.stringify(config).replace(/</g, String.raw`\u003c`);
   const scriptTag = `<script>window.__APP_CONFIG__=${safeJson};</script>`;
 
   if (HEAD_TAG_REGEX.test(rawHtml)) {
@@ -20,5 +20,5 @@ export function loadIndexHtml(filePath: string): string {
   if (!existsSync(filePath)) {
     return "";
   }
-  return readFileSync(filePath, "utf-8");
+  return readFileSync(filePath, "utf8");
 }

--- a/src/server/observability.e2e.test.ts
+++ b/src/server/observability.e2e.test.ts
@@ -13,7 +13,7 @@ interface CapturedTransaction {
       data?: Record<string, unknown>;
     };
   };
-  spans?: Array<{ op?: string }>;
+  spans?: { op?: string }[];
 }
 
 function transactionsFrom(envelopes: string[]): CapturedTransaction[] {
@@ -41,7 +41,7 @@ async function waitFor(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     // oxlint-disable-next-line no-await-in-loop -- polling helper: each check must run sequentially after the previous one
-    if (await predicate()) return;
+    if (await predicate()) {return;}
     // oxlint-disable-next-line no-await-in-loop -- polling delay must run sequentially between checks; Promise.all does not apply
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
@@ -54,7 +54,7 @@ async function reservePort(): Promise<number> {
     port: 0,
     fetch: () => new Response("reserved"),
   });
-  const port = reservation.port;
+  const {port} = reservation;
   await reservation.stop(true);
   if (port === undefined) {
     throw new Error("Bun did not assign a test server port");
@@ -105,7 +105,8 @@ describe("server observability end to end", () => {
       try {
         await waitFor(async () => {
           try {
-            return (await fetch(`${applicationOrigin}/api/health`)).ok;
+            const healthResponse = await fetch(`${applicationOrigin}/api/health`);
+            return healthResponse.ok;
           } catch {
             return false;
           }

--- a/src/server/observability.ts
+++ b/src/server/observability.ts
@@ -12,7 +12,7 @@ export function shouldTraceServerPath(pathname: string): boolean {
 }
 
 function requestPathname(url: string | undefined): string {
-  if (!url) return "";
+  if (!url) {return "";}
 
   try {
     return new URL(url, "http://sentry.local").pathname;
@@ -52,4 +52,4 @@ export function sentryRequestContext(): MiddlewareHandler {
   };
 }
 
-export { Sentry };
+export * as Sentry from "@sentry/hono/bun";

--- a/src/server/routes/facilities.test.ts
+++ b/src/server/routes/facilities.test.ts
@@ -26,7 +26,7 @@ describe("GET /api/facilities", () => {
   });
 
   it("parses campus time and passes the requested scope to the service", async () => {
-    const calls: Array<{ timestamp: string; scope: FacilityScope }> = [];
+    const calls: { timestamp: string; scope: FacilityScope }[] = [];
     const expected: FacilityStatus = {
       timestamp: "2026-08-20T15:30:00.000-05:00",
       facilities: {},

--- a/src/server/routes/facilities.ts
+++ b/src/server/routes/facilities.ts
@@ -27,7 +27,7 @@ function resolveTargetDateTime(
 ): DateTime {
   if (date && time) {
     const target = parseCampusRequestDateTime(date, time);
-    if (target.isValid) return target;
+    if (target.isValid) {return target;}
   }
 
   if (date || time) {

--- a/src/server/services/external-contracts.ts
+++ b/src/server/services/external-contracts.ts
@@ -91,15 +91,15 @@ const academicAvailabilitySchema = z.object({
   buildings: z.record(z.string(), academicBuildingSchema),
 });
 
+const reservationSlotSchema = z.object({
+  itemId: finiteNumberSchema,
+  start: z.string(),
+  end: z.string(),
+  className: optionalStringSchema,
+});
+
 const reservationResponseSchema = z.object({
-  slots: z.array(
-    z.object({
-      itemId: finiteNumberSchema,
-      start: z.string(),
-      end: z.string(),
-      className: optionalStringSchema,
-    }),
-  ),
+  slots: z.array(reservationSlotSchema),
 });
 
 const blockDetailsSchema = z.object({
@@ -129,7 +129,7 @@ export type AcademicAvailabilityPayload = z.output<
 >;
 
 function formatIssuePath(path: PropertyKey[]): string {
-  if (path.length === 0) return "root";
+  if (path.length === 0) {return "root";}
 
   return path.reduce<string>((formatted, segment) => {
     if (typeof segment === "number") {
@@ -143,7 +143,7 @@ function formatIssuePath(path: PropertyKey[]): string {
 
 export class ExternalResponseError extends Error {
   constructor(source: string, error: z.ZodError) {
-    const issue = error.issues[0];
+    const [issue] = error.issues;
     const detail = issue
       ? ` at ${formatIssuePath(issue.path)}: ${issue.message}`
       : "";

--- a/src/server/services/facilities.test.ts
+++ b/src/server/services/facilities.test.ts
@@ -102,7 +102,7 @@ describe("getFacilityStatus", () => {
 
   it("maps LibCal slots into current, upcoming, and unavailable rooms", async () => {
     const target = atCampusTime("2026-08-24 08:15:00");
-    const requests: Array<{ url: string; body: URLSearchParams }> = [];
+    const requests: { url: string; body: URLSearchParams }[] = [];
     const fetchLibCal: FacilitiesFetch = async (input, init) => {
       requests.push({
         url: String(input),
@@ -248,7 +248,7 @@ describe("getFacilityStatus", () => {
           buildings: {
             cif: {
               name: "Campus Instructional Facility",
-              coordinates: { latitude: 40.0, longitude: -88.0 },
+              coordinates: { latitude: 40, longitude: -88 },
               hours: { open: "07:00:00", close: "22:00:00" },
               isOpen: true,
               roomCounts: { available: 0, total: 0 },

--- a/src/server/services/facilities.ts
+++ b/src/server/services/facilities.ts
@@ -1,18 +1,18 @@
 import { createClient } from "@supabase/supabase-js";
-import { DateTime } from "luxon";
+import type { DateTime } from "luxon";
 import {
-  StudyRoom,
-  TimeSlot,
-  RoomReservations,
-  FormattedLibraryData,
-  ReservationResponse,
+  type StudyRoom,
+  type TimeSlot,
+  type RoomReservations,
+  type FormattedLibraryData,
+  type ReservationResponse,
+  type Facility,
+  type FacilityStatus,
+  type AcademicRoom,
+  type LibraryRoom,
+  type RoomReservation,
   FacilityType,
-  Facility,
-  FacilityStatus,
-  RoomStatus,
-  AcademicRoom,
-  LibraryRoom,
-  RoomReservation,
+  RoomStatus
 } from "../../types";
 import {
   getActiveLibraryHours,
@@ -88,7 +88,7 @@ async function getReservation(
     : nextDay.toFormat("yyyy-MM-dd");
 
   const payload = {
-    lid: lid,
+    lid,
     gid: "0",
     eid: "-1",
     seat: "false",
@@ -150,7 +150,7 @@ function calculateAvailabilityDuration(
   if (libraryClosingTime && endTime > libraryClosingTime) {
     endTime = libraryClosingTime;
   }
-  if (endTime <= fromTime) return 0;
+  if (endTime <= fromTime) {return 0;}
 
   let duration = wholeMinutesBetween(endTime, fromTime);
   let lastEnd = endTime;
@@ -159,16 +159,16 @@ function calculateAvailabilityDuration(
   while (i < slots.length) {
     const nextSlot = slots[i];
     // Stop if the next slot is a reservation
-    if (nextSlot.className === "s-lc-eq-checkout") break;
+    if (nextSlot.className === "s-lc-eq-checkout") {break;}
 
     const nextStart = parseCampusTimestamp(nextSlot.start);
     let nextEnd = parseCampusTimestamp(nextSlot.end);
 
-    if (lastEnd.toMillis() !== nextStart.toMillis()) break;
+    if (lastEnd.toMillis() !== nextStart.toMillis()) {break;}
 
     if (libraryClosingTime) {
-      if (nextStart >= libraryClosingTime) break;
-      if (nextEnd > libraryClosingTime) nextEnd = libraryClosingTime;
+      if (nextStart >= libraryClosingTime) {break;}
+      if (nextEnd > libraryClosingTime) {nextEnd = libraryClosingTime;}
     }
 
     duration += wholeMinutesBetween(nextEnd, nextStart);
@@ -213,16 +213,16 @@ function linkRoomsReservations(
   const targetDateTimeString = targetDateTime.toFormat("yyyy-MM-dd HH:mm:ss");
 
   for (const room of roomsData) {
-    if (!libraryIds.has(room.lid)) continue;
+    if (!libraryIds.has(room.lid)) {continue;}
 
     const libraryName = Object.values(LIBRARIES).find(
       (l) => l.id === room.lid.toString(),
     )?.name;
-    if (!libraryName) continue; // Should not happen
+    if (!libraryName) {continue;} // Should not happen
 
     const roomId = room.eid;
     let availableAt: string | undefined = undefined;
-    let availableDuration: number = 0;
+    let availableDuration = 0;
     let isCurrentlyAvailable = false;
     let roomStatus: RoomStatus = RoomStatus.RESERVED; // Default status
 
@@ -316,16 +316,13 @@ function linkRoomsReservations(
           libraryClosingTime,
         );
 
-        if (
+        // It's available later, but not "soon", keep status as RESERVED/OCCUPIED for now
+        roomStatus =
           availableAt &&
           isOpeningSoon(availableAt, targetDateTime) &&
           availableDuration >= 30
-        ) {
-          roomStatus = RoomStatus.OPENING_SOON;
-        } else {
-          // It's available later, but not "soon", keep status as RESERVED/OCCUPIED for now
-          roomStatus = RoomStatus.RESERVED;
-        }
+            ? RoomStatus.OPENING_SOON
+            : RoomStatus.RESERVED;
       } else {
         // Not available now and no future availability found within operating hours
         roomStatus = RoomStatus.RESERVED; // Or OCCUPIED, depending on context, RESERVED fits library
@@ -414,7 +411,7 @@ async function getFormattedLibraryData(
   // isolated so one unavailable LibCal calendar does not erase other results.
   const libraryPromises = openLibraries.map(async (libraryName) => {
     const libraryInfo = LIBRARIES[libraryName];
-    if (!libraryInfo) return null; // Should not happen if openLibraries is correct
+    if (!libraryInfo) {return null;} // Should not happen if openLibraries is correct
 
     const lid = libraryInfo.id;
     const libraryRooms = STATIC_ROOMS_BY_LIBRARY[lid] || [];
@@ -575,22 +572,18 @@ async function fetchAcademicBuildingData(
     Object.entries(building.rooms).forEach(([roomNumber, roomData]) => {
       let status: RoomStatus;
       if (roomData.status === "available") {
-        if (roomData.passingPeriod) {
-          status = RoomStatus.PASSING_PERIOD;
-        } else {
-          status = RoomStatus.AVAILABLE;
-        }
+        status = roomData.passingPeriod
+          ? RoomStatus.PASSING_PERIOD
+          : RoomStatus.AVAILABLE;
+      } else if (
+        roomData.availableAt &&
+        isOpeningSoon(roomData.availableAt, targetDateTime) &&
+        roomData.availableFor &&
+        roomData.availableFor >= 30
+      ) {
+        status = RoomStatus.OPENING_SOON;
       } else {
-        if (
-          roomData.availableAt &&
-          isOpeningSoon(roomData.availableAt, targetDateTime) &&
-          roomData.availableFor &&
-          roomData.availableFor >= 30
-        ) {
-          status = RoomStatus.OPENING_SOON;
-        } else {
-          status = RoomStatus.OCCUPIED;
-        }
+        status = RoomStatus.OCCUPIED;
       }
 
       academicFacility.rooms[roomNumber] = {
@@ -701,7 +694,7 @@ async function updateLibraryFacilities(
 
   Object.entries(libraryData).forEach(([name, data]) => {
     const libraryFacility = libraryFacilities[name];
-    if (!libraryFacility?.isOpen) return;
+    if (!libraryFacility?.isOpen) {return;}
 
     libraryFacility.roomCounts = {
       available: data.currently_available,

--- a/src/server/services/library-hours.ts
+++ b/src/server/services/library-hours.ts
@@ -16,7 +16,7 @@ export function getActiveLibraryHours(
   for (const dayOffset of [0, -1]) {
     const scheduleDate = target.plus({ days: dayOffset }).startOf("day");
     const hours = LIBRARY_HOURS[libraryName]?.[scheduleDate.weekdayLong ?? ""];
-    if (!hours) continue;
+    if (!hours) {continue;}
 
     const open = DateTime.fromFormat(
       `${scheduleDate.toFormat("yyyy-MM-dd")} ${hours.open}`,
@@ -28,7 +28,7 @@ export function getActiveLibraryHours(
       "yyyy-MM-dd HH:mm",
       { zone: CAMPUS_TIMEZONE },
     );
-    if (hours.nextDay) close = close.plus({ days: 1 });
+    if (hours.nextDay) {close = close.plus({ days: 1 });}
 
     if (open.isValid && close.isValid && target >= open && target < close) {
       return { open, close };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,9 +90,7 @@ export interface Library {
   isOpen?: boolean;
 }
 
-export interface Libraries {
-  [key: string]: Library;
-}
+export type Libraries = Record<string, Library>;
 
 export interface StudyRoom {
   id: string;
@@ -122,9 +120,7 @@ export interface RoomReservation {
   status: RoomStatus;
 }
 
-export interface RoomReservations {
-  [key: string]: RoomReservation;
-}
+export type RoomReservations = Record<string, RoomReservation>;
 
 export interface LibraryData {
   room_count: number;
@@ -134,9 +130,7 @@ export interface LibraryData {
   isOpen?: boolean;
 }
 
-export interface FormattedLibraryData {
-  [key: string]: LibraryData;
-}
+export type FormattedLibraryData = Record<string, LibraryData>;
 
 export interface APIResponse {
   timezone: string;
@@ -222,9 +216,7 @@ export interface FacilityRoomProps {
   facilityId: string;
   facilityName: string;
 }
-export interface AccordionRefs {
-  [key: string]: HTMLDivElement | null;
-}
+export type AccordionRefs = Record<string, HTMLDivElement | null>;
 
 export interface RoomBadgeProps {
   status: RoomStatus;

--- a/src/utils/filterUtils.test.ts
+++ b/src/utils/filterUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { isRoomAvailable } from "@/utils/filterUtils";
-import { AcademicRoom, FacilityRoom, RoomStatus } from "@/types";
+import { type AcademicRoom, type FacilityRoom, RoomStatus } from "@/types";
 
 const createRoom = (overrides: Partial<AcademicRoom> = {}): FacilityRoom => ({
   type: "academic",

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -1,4 +1,4 @@
-import { FacilityRoom, RoomStatus } from "@/types";
+import { type FacilityRoom, RoomStatus } from "@/types";
 import { getCampusDateTimeParts, parseTimeToMinutes } from "@/utils/time";
 
 export interface FilterCriteria {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -2,8 +2,8 @@
  * Formats a duration in minutes to a human-readable string.
  */
 export const formatDuration = (minutes: number | undefined): string => {
-  if (!minutes) return "";
-  if (minutes < 60) return `${Math.floor(minutes)} min`;
+  if (!minutes) {return "";}
+  if (minutes < 60) {return `${Math.floor(minutes)} min`;}
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = Math.floor(minutes % 60);
   return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;

--- a/src/utils/libraryHours.ts
+++ b/src/utils/libraryHours.ts
@@ -4,15 +4,11 @@ import {
   getDateWeekday,
 } from "./time";
 
-export interface LibraryHours {
-  [key: string]: {
-    [day: string]: {
+export type LibraryHours = Record<string, Record<string, {
       open: string;
       close: string;
       nextDay?: boolean;
-    };
-  };
-}
+    }>>;
 
 export const LIBRARY_HOURS: LibraryHours = {
   "Grainger Engineering Library": {
@@ -50,7 +46,7 @@ export const getLibraryHoursMessage = (
 ): string => {
   const dayOfWeek = getDateWeekday(date);
   const hours = dayOfWeek ? LIBRARY_HOURS[libraryName]?.[dayOfWeek] : undefined;
-  if (!hours) return "Hours not available for this day";
+  if (!hours) {return "Hours not available for this day";}
 
   return `Reservable hours for ${dayOfWeek}: ${formatTimeForDisplay(hours.open)} - ${formatTimeForDisplay(hours.close)}${hours.nextDay ? " (next day)" : ""}`;
 };

--- a/src/utils/liveUpdates.test.ts
+++ b/src/utils/liveUpdates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { FacilityStatus, FacilityType, RoomStatus } from "@/types";
+import { type FacilityStatus, FacilityType, RoomStatus } from "@/types";
 import {
   ageLiveAvailability,
   shouldRefetchFacilitiesOnReconnect,

--- a/src/utils/liveUpdates.ts
+++ b/src/utils/liveUpdates.ts
@@ -1,4 +1,4 @@
-import { FacilityStatus, RoomStatus } from "@/types";
+import { type FacilityStatus, RoomStatus } from "@/types";
 
 export const LIVE_REFRESH_INTERVAL_MS = 5 * 60_000;
 
@@ -13,16 +13,16 @@ export function ageLiveAvailability(
   data: FacilityStatus | undefined,
   now: Date,
 ): FacilityStatus | undefined {
-  if (!data) return undefined;
+  if (!data) {return undefined;}
 
   const timestamp = Date.parse(data.timestamp);
-  if (!Number.isFinite(timestamp)) return data;
+  if (!Number.isFinite(timestamp)) {return data;}
 
   const elapsedMinutes = Math.max(
     0,
     Math.floor((now.getTime() - timestamp) / 60_000),
   );
-  if (elapsedMinutes === 0) return data;
+  if (elapsedMinutes === 0) {return data;}
 
   return {
     ...data,

--- a/src/utils/loadingMetrics.ts
+++ b/src/utils/loadingMetrics.ts
@@ -17,7 +17,7 @@ export function recordInitialLoadMilestone(
   milestone: InitialLoadMilestone,
   mapEnabled: boolean,
 ): void {
-  if (typeof performance === "undefined") return;
+  if (typeof performance === "undefined") {return;}
 
   try {
     Sentry.metrics.distribution(

--- a/src/utils/naturalLanguageSearch.ts
+++ b/src/utils/naturalLanguageSearch.ts
@@ -19,7 +19,7 @@ export interface NaturalLanguageSearchResult {
 
 function removeMatchedText(
   query: string,
-  matches: Array<{ index: number; text: string }>,
+  matches: { index: number; text: string }[],
 ): string {
   let locationQuery = query;
 
@@ -80,7 +80,7 @@ export function parseNaturalLanguageSearch(
     };
   }
 
-  const match = matches[0];
+  const [match] = matches;
   const hasExplicitHour = match.start.isCertain("hour");
   const hour = match.start.get("hour");
   if (
@@ -98,25 +98,22 @@ export function parseNaturalLanguageSearch(
     };
   }
 
-  let target: TZDate;
-  if (match.start.isCertain("timezoneOffset")) {
-    // Rebuilding relative durations from wall-clock parts loses time at DST boundaries.
-    target = TZDate.tz(CAMPUS_TIMEZONE, match.start.date());
-  } else {
-    target = TZDate.tz(
-      CAMPUS_TIMEZONE,
-      match.start.get("year") ?? campusReference.getFullYear(),
-      (match.start.get("month") ?? campusReference.getMonth() + 1) - 1,
-      match.start.get("day") ?? campusReference.getDate(),
-      hasExplicitHour
-        ? (match.start.get("hour") ?? campusReference.getHours())
-        : campusReference.getHours(),
-      hasExplicitHour
-        ? (match.start.get("minute") ?? 0)
-        : campusReference.getMinutes(),
-      0,
-    );
-  }
+  // Rebuilding relative durations from wall-clock parts loses time at DST boundaries.
+  const target: TZDate = match.start.isCertain("timezoneOffset")
+    ? TZDate.tz(CAMPUS_TIMEZONE, match.start.date())
+    : TZDate.tz(
+        CAMPUS_TIMEZONE,
+        match.start.get("year") ?? campusReference.getFullYear(),
+        (match.start.get("month") ?? campusReference.getMonth() + 1) - 1,
+        match.start.get("day") ?? campusReference.getDate(),
+        hasExplicitHour
+          ? (match.start.get("hour") ?? campusReference.getHours())
+          : campusReference.getHours(),
+        hasExplicitHour
+          ? (match.start.get("minute") ?? 0)
+          : campusReference.getMinutes(),
+        0,
+      );
 
   if (Number.isNaN(target.getTime())) {
     return {

--- a/src/utils/scheduleUtils.ts
+++ b/src/utils/scheduleUtils.ts
@@ -1,4 +1,4 @@
-import { RoomScheduleBlock, HourlyScheduleBlock, BlockSection } from "@/types";
+import type { RoomScheduleBlock, HourlyScheduleBlock, BlockSection } from "@/types";
 import { formatMinutesAsTime, parseTimeToMinutes } from "@/utils/time";
 
 interface ParsedScheduleBlock {
@@ -17,7 +17,7 @@ export function processScheduleIntoHourlyBlocks(
       ? [{ block, start, end }]
       : [];
   });
-  if (parsed.length === 0) return [];
+  if (parsed.length === 0) {return [];}
 
   parsed.sort((left, right) => left.start - right.start);
   const firstStart = parsed[0].start;

--- a/src/utils/searchUtils.test.ts
+++ b/src/utils/searchUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { performSearch, getBuildingAliases, searchFacilities } from "@/utils/searchUtils";
-import { Facility, FacilityType, RoomStatus } from "@/types";
+import { type Facility, FacilityType, RoomStatus } from "@/types";
 
 const mockFacilities: Facility[] = [
   {

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -1,6 +1,6 @@
-import { Facility, FacilityRoom, RoomStatus } from "@/types";
-import { FilterCriteria, isRoomAvailable } from "@/utils/filterUtils";
-import uFuzzy from "@leeoniya/ufuzzy";
+import { type Facility, type FacilityRoom, RoomStatus } from "@/types";
+import { type FilterCriteria, isRoomAvailable } from "@/utils/filterUtils";
+import UFuzzy from "@leeoniya/ufuzzy";
 
 export const BUILDING_ALIASES: Record<string, string[]> = {
   "Campus Instructional Facility": ["cif", "campus instructional", "instructional facility"],
@@ -80,10 +80,10 @@ export const getBuildingAliases = (buildingName: string): string[] => {
     }
   }
 
-  return Array.from(aliases);
+  return [...aliases];
 };
 
-const uf = new uFuzzy({ intraMode: 1, intraIns: 1 });
+const uf = new UFuzzy({ intraMode: 1, intraIns: 1 });
 
 const findRankedMatches = (haystack: string[], query: string): number[] => {
   const [idxs, info, order] = uf.search(
@@ -93,7 +93,7 @@ const findRankedMatches = (haystack: string[], query: string): number[] => {
     Number.POSITIVE_INFINITY,
   );
 
-  if (!idxs || idxs.length === 0) return [];
+  if (!idxs || idxs.length === 0) {return [];}
   return info && order ? order.map((index) => info.idx[index]) : idxs;
 };
 
@@ -120,7 +120,7 @@ const getStatusRank = (status: RoomStatus): number => {
  */
 export const searchFacilities = (facilities: Facility[], searchTerm: string): Facility[] => {
   const query = searchTerm.trim();
-  if (!query) return facilities;
+  if (!query) {return facilities;}
 
   const haystack = facilities.map(
     (facility) => `${facility.name} ${getBuildingAliases(facility.name).join(" ")}`
@@ -135,10 +135,10 @@ export const performSearch = (
   facilities: Facility[],
   searchTerm: string,
   filterCriteria: FilterCriteria = {},
-  hasActiveFilters: boolean = false,
+  hasActiveFilters = false,
 ): SearchResultRoom[] => {
   const query = searchTerm.trim().toLowerCase();
-  if (!query) return [];
+  if (!query) {return [];}
 
   const queryTokens = query.split(/\s+/).filter(Boolean);
 
@@ -174,11 +174,11 @@ export const performSearch = (
     });
   });
 
-  if (roomIndexItems.length === 0) return [];
+  if (roomIndexItems.length === 0) {return [];}
 
   const haystack = roomIndexItems.map((item) => item.searchableString);
   const matchedIndices = findRankedMatches(haystack, query);
-  if (matchedIndices.length === 0) return [];
+  if (matchedIndices.length === 0) {return [];}
 
   const getMatchPriority = (item: RoomIndexItem): number => {
     const r = item.roomNumber.toLowerCase();
@@ -216,11 +216,11 @@ export const performSearch = (
 
   matchedRooms.sort((a, b) => {
     // 1. Query specificity priority (compound match > exact room match > broad match)
-    if (a.priority !== b.priority) return b.priority - a.priority;
+    if (a.priority !== b.priority) {return b.priority - a.priority;}
 
     // 2. Room availability status (Available / Passing Period > Opening Soon > Occupied > Closed)
     const rankDiff = getStatusRank(b.item.room.status) - getStatusRank(a.item.room.status);
-    if (rankDiff !== 0) return rankDiff;
+    if (rankDiff !== 0) {return rankDiff;}
 
     // 3. uFuzzy relevance rank
     return a.uFuzzyRank - b.uFuzzyRank;

--- a/src/utils/storageStore.test.tsx
+++ b/src/utils/storageStore.test.tsx
@@ -27,7 +27,7 @@ describe("storageStore", () => {
 
     globalThis.window = {
       addEventListener: (type: string, listener: (event: StorageEvent) => void) => {
-        if (type === "storage") storageListeners.push(listener);
+        if (type === "storage") {storageListeners.push(listener);}
       },
       removeEventListener: (type: string, listener: (event: StorageEvent) => void) => {
         if (type === "storage") {

--- a/src/utils/storageStore.ts
+++ b/src/utils/storageStore.ts
@@ -15,7 +15,7 @@ export function createLocalStorageStore<T>(
   serialize: (val: T) => string = (v) => JSON.stringify(v),
 ): StorageStore<T> {
   const read = (): T => {
-    if (typeof window === "undefined") return defaultValue;
+    if (typeof window === "undefined") {return defaultValue;}
     try {
       return parse(localStorage.getItem(key));
     } catch {
@@ -58,7 +58,7 @@ export function createLocalStorageStore<T>(
         typeof value === "function"
           ? (value as (prev: T) => T)(snapshot)
           : value;
-      if (snapshot === next) return;
+      if (snapshot === next) {return;}
       snapshot = next;
       if (typeof window !== "undefined") {
         try {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,7 +1,7 @@
 export const CAMPUS_TIMEZONE = "America/Chicago";
 
-const TIME_PATTERN = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/;
-const DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const TIME_PATTERN = /^(?<hour>\d{1,2}):(?<minute>\d{2})(?::(?<second>\d{2}))?$/;
+const DATE_PATTERN = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/;
 const MINUTES_PER_DAY = 24 * 60;
 
 const campusPartsFormatter = new Intl.DateTimeFormat("en-US", {
@@ -47,7 +47,7 @@ function readNumericPart(
   type: Intl.DateTimeFormatPartTypes,
 ): number {
   const part = parts.find((candidate) => candidate.type === type);
-  if (!part) throw new Error(`Intl formatter omitted ${type}`);
+  if (!part) {throw new Error(`Intl formatter omitted ${type}`);}
   return Number(part.value);
 }
 
@@ -73,7 +73,7 @@ export function getCampusDateTimeParts(
 
 export function parseTimeToMinutes(time: string): number | null {
   const match = TIME_PATTERN.exec(time);
-  if (!match) return null;
+  if (!match) {return null;}
 
   const hour = Number(match[1]);
   const minute = Number(match[2]);
@@ -103,9 +103,9 @@ export function formatMinutesAsTime(minutes: number): string {
 }
 
 export function formatTimeForDisplay(time: string | undefined): string {
-  if (!time) return "";
+  if (!time) {return "";}
   const minutes = parseTimeToMinutes(time);
-  if (minutes === null) return time;
+  if (minutes === null) {return time;}
 
   const hour = Math.floor(minutes / 60) % 24;
   const minute = Math.floor(minutes % 60);
@@ -130,13 +130,13 @@ export function getOvernightDurationMinutes(
   end: string,
 ): number {
   const duration = timeDifference(start, end);
-  if (duration === null) return 0;
+  if (duration === null) {return 0;}
   return duration < 0 ? duration + MINUTES_PER_DAY : duration;
 }
 
 function dateToUtc(date: string): Date | null {
   const match = DATE_PATTERN.exec(date);
-  if (!match) return null;
+  if (!match) {return null;}
 
   const year = Number(match[1]);
   const month = Number(match[2]);
@@ -154,7 +154,7 @@ function dateToUtc(date: string): Date | null {
 
 export function addDateDays(date: string, days: number): string | null {
   const value = dateToUtc(date);
-  if (!value) return null;
+  if (!value) {return null;}
   value.setUTCDate(value.getUTCDate() + days);
   return value.toISOString().slice(0, 10);
 }
@@ -162,13 +162,13 @@ export function addDateDays(date: string, days: number): string | null {
 export function differenceInCalendarDays(left: string, right: string): number | null {
   const leftDate = dateToUtc(left);
   const rightDate = dateToUtc(right);
-  if (!leftDate || !rightDate) return null;
+  if (!leftDate || !rightDate) {return null;}
   return Math.round((leftDate.getTime() - rightDate.getTime()) / 86_400_000);
 }
 
 export function getDateWeekday(date: string, short = false): string | null {
   const value = dateToUtc(date);
-  if (!value) return null;
+  if (!value) {return null;}
   return (short ? shortWeekdayFormatter : weekdayFormatter).format(value);
 }
 
@@ -179,7 +179,7 @@ export function formatDateForDisplay(date: string): string {
 
 export function formatShortMonthDay(date: string): string {
   const match = DATE_PATTERN.exec(date);
-  if (!match) return date;
+  if (!match) {return date;}
   return `${Number(match[2])}/${Number(match[3])}`;
 }
 

--- a/src/utils/timelineSchedule.ts
+++ b/src/utils/timelineSchedule.ts
@@ -72,7 +72,7 @@ export function formatDuration(minutes: number): string {
   if (hours > 0 && remainingMinutes > 0) {
     return `${hours}h ${remainingMinutes}m`;
   }
-  if (hours > 0) return `${hours}h`;
+  if (hours > 0) {return `${hours}h`;}
   return `${remainingMinutes}m`;
 }
 
@@ -154,7 +154,7 @@ export function buildTimelineModel(
     const clippedStart = Math.max(startMinutes, parsed.startMinutes);
     const clippedEnd = Math.min(endMinutes, parsed.endMinutes);
     const durationMinutes = clippedEnd - clippedStart;
-    if (durationMinutes <= 0) return [];
+    if (durationMinutes <= 0) {return [];}
 
     const offsetMinutes = clippedStart - startMinutes;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(({ mode }) => {
     ],
     resolve: {
       alias: {
-        "@": fileURLToPath(new URL("./src", import.meta.url)),
+        "@": fileURLToPath(new URL("src", import.meta.url)),
       },
     },
     server: {


### PR DESCRIPTION
In order to catch style drift the same way correctness and perf issues are already caught, this PR enables oxlint's `style` category (as warnings) and clears all 188 resulting warnings, so `bun run lint` is fully clean.

A blanket enable fires ~2,400 violations from rules that fight this stack (ternary bans, null bans, kebab-case filenames), so 22 such rules stay `off` in `.oxlintrc.json`. The one inline suppression is `hook-use-state` in `providers.tsx`, where the setter-less `useState` lazy singleton is intentional — the ref-based alternative trips `react/refs`.

### Change type

- [x] `other`

### Test plan

- [x] Unit tests — existing suite passes unchanged (123/123); no behavior changes, so no new tests
- `bun run lint`: 0 warnings, 0 errors
- `bun run build` (includes typecheck): succeeds

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +253 / -286 |
| Tests          | +15 / -14   |
| Config/tooling | +26 / -2    |