### PR TITLE
feat(sidebar): Add draggable resize handle between list and map

### DIFF
--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -68,7 +68,7 @@ const readInitialSidebarWidth = () => {
     const raw = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
     const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
     if (Number.isFinite(parsed)) {
-      return clampSidebarWidth(parsed);
+      return clampSidebarWidth(parsed, window.innerWidth);
     }
     return clampSidebarWidth(window.innerWidth * 0.37);
   } catch {
@@ -113,6 +113,28 @@ const IlliniSpotsPage: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const pendingWidthRef = useRef(sidebarWidth);
+  const [containerWidth, setContainerWidth] = useState<number | undefined>(() =>
+    typeof window === "undefined" ? undefined : window.innerWidth,
+  );
+
+  // Re-clamp the restored width whenever the container changes. The stored
+  // preference is untouched; only the effective width shrinks until there
+  // is room again, keeping the box, separator, and ARIA value in sync.
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element || typeof ResizeObserver === "undefined") {return;}
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) {setContainerWidth(width);}
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  const effectiveSidebarWidth = clampSidebarWidth(
+    sidebarWidth,
+    containerWidth,
+  );
 
   const commitSidebarWidth = useCallback((width: number) => {
     const next = clampSidebarWidth(
@@ -137,7 +159,10 @@ const IlliniSpotsPage: React.FC = () => {
       event.currentTarget.setPointerCapture(event.pointerId);
       dragRef.current = {
         startX: event.clientX,
-        startWidth: pendingWidthRef.current,
+        startWidth: clampSidebarWidth(
+          pendingWidthRef.current,
+          containerRef.current?.getBoundingClientRect().width,
+        ),
       };
       document.body.style.userSelect = "none";
       document.body.style.cursor = "col-resize";
@@ -172,10 +197,10 @@ const IlliniSpotsPage: React.FC = () => {
       const step = event.shiftKey ? 64 : 16;
       if (event.key === "ArrowLeft") {
         event.preventDefault();
-        commitSidebarWidth(pendingWidthRef.current - step);
+        commitSidebarWidth(effectiveSidebarWidth - step);
       } else if (event.key === "ArrowRight") {
         event.preventDefault();
-        commitSidebarWidth(pendingWidthRef.current + step);
+        commitSidebarWidth(effectiveSidebarWidth + step);
       } else if (event.key === "Home") {
         event.preventDefault();
         commitSidebarWidth(SIDEBAR_MIN_WIDTH);
@@ -184,7 +209,7 @@ const IlliniSpotsPage: React.FC = () => {
         commitSidebarWidth(SIDEBAR_MAX_WIDTH);
       }
     },
-    [commitSidebarWidth],
+    [commitSidebarWidth, effectiveSidebarWidth],
   );
 
   const handleExpandedFacilityIdsChange = useCallback(
@@ -363,7 +388,7 @@ const IlliniSpotsPage: React.FC = () => {
       className={mainContentClasses}
       style={
         showMap
-          ? ({ "--sidebar-width": `${sidebarWidth}px` } as React.CSSProperties)
+          ? ({ "--sidebar-width": `${effectiveSidebarWidth}px` } as React.CSSProperties)
           : undefined
       }
     >
@@ -400,7 +425,7 @@ const IlliniSpotsPage: React.FC = () => {
           aria-label="Resize sidebar"
           aria-valuemin={SIDEBAR_MIN_WIDTH}
           aria-valuemax={SIDEBAR_MAX_WIDTH}
-          aria-valuenow={sidebarWidth}
+          aria-valuenow={effectiveSidebarWidth}
           tabIndex={0}
           title="Drag to resize (double-click to reset)"
           onPointerDown={handleResizePointerDown}

--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -44,6 +44,38 @@ function MapLoadingFallback() {
   );
 }
 
+const SIDEBAR_WIDTH_STORAGE_KEY = "illinispots:sidebarWidth";
+const SIDEBAR_MIN_WIDTH = 320;
+const SIDEBAR_MAX_WIDTH = 720;
+const SIDEBAR_DEFAULT_WIDTH = 480;
+const MAP_MIN_WIDTH = 340;
+
+const clampSidebarWidth = (width: number, containerWidth?: number) => {
+  const maxByMap =
+    containerWidth && containerWidth > 0
+      ? containerWidth - MAP_MIN_WIDTH
+      : SIDEBAR_MAX_WIDTH;
+  return Math.min(
+    SIDEBAR_MAX_WIDTH,
+    maxByMap,
+    Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)),
+  );
+};
+
+const readInitialSidebarWidth = () => {
+  if (typeof window === "undefined") {return SIDEBAR_DEFAULT_WIDTH;}
+  try {
+    const raw = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    if (Number.isFinite(parsed)) {
+      return clampSidebarWidth(parsed);
+    }
+    return clampSidebarWidth(window.innerWidth * 0.37);
+  } catch {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+};
+
 const fetchFacilityData = async (
   selectedDateTime: CampusDateTime,
   type: "academic" | "library",
@@ -75,6 +107,85 @@ const IlliniSpotsPage: React.FC = () => {
     id: string | null;
     timestamp: number;
   }>({ id: null, timestamp: 0 });
+  const [sidebarWidth, setSidebarWidth] = useState<number>(
+    readInitialSidebarWidth,
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const pendingWidthRef = useRef(sidebarWidth);
+
+  const commitSidebarWidth = useCallback((width: number) => {
+    const next = clampSidebarWidth(
+      width,
+      containerRef.current?.getBoundingClientRect().width,
+    );
+    pendingWidthRef.current = next;
+    containerRef.current?.style.setProperty("--sidebar-width", `${next}px`);
+    setSidebarWidth(next);
+    try {
+      window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(next));
+    } catch {
+      // Storage unavailable, width still applies for this session.
+    }
+  }, []);
+
+  // During a drag the width is written straight to the container's CSS
+  // variable so the list does not re-render on every pixel. React state
+  // only commits on release.
+  const handleResizePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.currentTarget.setPointerCapture(event.pointerId);
+      dragRef.current = {
+        startX: event.clientX,
+        startWidth: pendingWidthRef.current,
+      };
+      document.body.style.userSelect = "none";
+      document.body.style.cursor = "col-resize";
+    },
+    [],
+  );
+
+  const handleResizePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag) {return;}
+      const next = clampSidebarWidth(
+        drag.startWidth + (event.clientX - drag.startX),
+        containerRef.current?.getBoundingClientRect().width,
+      );
+      pendingWidthRef.current = next;
+      containerRef.current?.style.setProperty("--sidebar-width", `${next}px`);
+    },
+    [],
+  );
+
+  const endResizeDrag = useCallback(() => {
+    if (!dragRef.current) {return;}
+    dragRef.current = null;
+    document.body.style.userSelect = "";
+    document.body.style.cursor = "";
+    commitSidebarWidth(pendingWidthRef.current);
+  }, [commitSidebarWidth]);
+
+  const handleResizeKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const step = event.shiftKey ? 64 : 16;
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        commitSidebarWidth(pendingWidthRef.current - step);
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        commitSidebarWidth(pendingWidthRef.current + step);
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        commitSidebarWidth(SIDEBAR_MIN_WIDTH);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        commitSidebarWidth(SIDEBAR_MAX_WIDTH);
+      }
+    },
+    [commitSidebarWidth],
+  );
 
   const handleExpandedFacilityIdsChange = useCallback(
     (facilityIds: string[]) => {
@@ -242,30 +353,26 @@ const IlliniSpotsPage: React.FC = () => {
   );
 
   const showFetchingOverlay = isAcademicFetching && !isAcademicLoading;
-  const mainContentClasses = `h-screen flex ${
+  const mainContentClasses = `h-screen relative flex ${
     showMap ? "md:flex-row" : "items-center bg-muted/20"
   } flex-col`;
 
   return (
-    <div className={mainContentClasses}>
-      {showMap && (
-        <div className="h-[40vh] md:h-screen md:w-[63%] w-full order-1 md:order-2">
-          <Suspense fallback={<MapLoadingFallback />}>
-            <FacilityMap
-              facilityData={facilityData || null}
-              onMarkerClick={handleMarkerClick}
-              trackInitialLoad
-            />
-          </Suspense>
-        </div>
-      )}
-
+    <div
+      ref={containerRef}
+      className={mainContentClasses}
+      style={
+        showMap
+          ? ({ "--sidebar-width": `${sidebarWidth}px` } as React.CSSProperties)
+          : undefined
+      }
+    >
       <div
         className={`${
           showMap
-            ? "md:w-[37%] h-[60vh] md:h-screen order-2 md:order-1"
-            : "h-screen max-w-3xl md:border-x border-border shadow-xs"
-        } w-full flex-1 overflow-hidden relative`}
+            ? "h-[60vh] md:h-screen order-2 md:order-1 w-full md:w-[var(--sidebar-width)] md:min-w-[320px] md:max-w-[calc(100%-340px)] md:shrink-0 md:grow-0"
+            : "h-screen max-w-3xl md:border-x border-border shadow-xs w-full flex-1"
+        } overflow-hidden relative`}
       >
         <LeftSidebar
           facilityData={facilityData || null}
@@ -285,6 +392,40 @@ const IlliniSpotsPage: React.FC = () => {
           }}
         />
       </div>
+
+      {showMap && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize sidebar"
+          aria-valuemin={SIDEBAR_MIN_WIDTH}
+          aria-valuemax={SIDEBAR_MAX_WIDTH}
+          aria-valuenow={sidebarWidth}
+          tabIndex={0}
+          title="Drag to resize (double-click to reset)"
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={handleResizePointerMove}
+          onPointerUp={endResizeDrag}
+          onPointerCancel={endResizeDrag}
+          onKeyDown={handleResizeKeyDown}
+          onDoubleClick={() => commitSidebarWidth(SIDEBAR_DEFAULT_WIDTH)}
+          className="hidden md:flex md:absolute md:left-[var(--sidebar-width)] md:top-0 md:bottom-0 md:z-20 md:-translate-x-1/2 w-2 cursor-col-resize touch-none select-none items-stretch justify-center bg-transparent opacity-0 transition-[background-color,opacity] hover:bg-primary/15 hover:opacity-100 active:bg-primary/25 active:opacity-100 focus-visible:bg-primary/15 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset focus-visible:outline-none"
+        >
+          <div className="w-px bg-border" aria-hidden="true" />
+        </div>
+      )}
+
+      {showMap && (
+        <div className="h-[40vh] md:h-screen w-full md:w-auto md:flex-1 md:min-w-0 order-1 md:order-3">
+          <Suspense fallback={<MapLoadingFallback />}>
+            <FacilityMap
+              facilityData={facilityData || null}
+              onMarkerClick={handleMarkerClick}
+              trackInitialLoad
+            />
+          </Suspense>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/left.tsx
+++ b/src/components/left.tsx
@@ -346,7 +346,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     return (
         <div
             className={`h-full bg-background flex flex-col relative ${
-                showMap ? "border-t md:border-t-0 md:border-r" : ""
+                showMap ? "border-t md:border-t-0" : ""
             }`}
         >
             <div className="sidebar-header py-2 px-3 md:py-3 md:px-4 border-b flex select-none items-center gap-2">

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -175,6 +175,27 @@ export default function FacilityMap({
     };
   }, []);
 
+  // Keep the map canvas in sync when the container is resized
+  // (e.g. sidebar drag). Throttled with rAF so continuous drags
+  // repaint instead of re-fetching tiles.
+  useEffect(() => {
+    if (!map.current || !mapContainer.current || !isMapLoaded) {return;}
+
+    let raf = 0;
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        map.current?.resize();
+      });
+    });
+    observer.observe(mapContainer.current);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+    };
+  }, [isMapLoaded]);
+
   useEffect(() => {
     if (!map.current || !isMapLoaded || !facilityData) {return;}
 


### PR DESCRIPTION
In order to let desktop users give the list or the map more room, this PR adds a draggable resize handle between the sidebar and the map. The fixed 37/63 split stays as the default for fresh visitors.

The handle only exists on desktop and stays invisible until hovered, dragged, or keyboard focused, floating over the map edge so it takes no layout space. Width clamps to 320-720px while always leaving 340px for the map, persists to localStorage, resets on double-click, and supports arrow keys with shift for larger steps. Drags write straight to a CSS variable and only commit to state on release, so the facility list does not re-render per pixel. The map follows container resizes through a rAF-throttled ResizeObserver, which repaints cached tiles rather than refetching.

### Change type

- [x] `feature`

### Test plan

1. Open the app on desktop with the map shown and drag the sidebar edge.
2. Confirm the list does not flicker, the map tracks smoothly, and the width persists across reload.
3. Double-click the handle to reset, and check arrow-key resizing when the handle is focused.
4. `bun run test` (123 pass), `bun run typecheck`, `bun run lint`, `bun run build` all green.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add draggable sidebar width with hover-only handle on desktop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a resizable sidebar with mouse and keyboard controls.
  * Sidebar width is remembered between sessions.
  * Added accessible resizing controls with minimum and maximum width limits.

* **Bug Fixes**
  * Improved map rendering while resizing the sidebar.
  * Updated borders and layout behavior for map and sidebar views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->